### PR TITLE
Output keys instead of index for error columns

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -225,7 +225,7 @@ def row_validation_error(rule, row_dict):
         'message':
         rule.get('message', '').format(**row_dict),
         'error_columns': [
-            idx for (idx, k) in enumerate(row_dict.keys())
+            k for (idx, k) in enumerate(row_dict.keys())
             if k in rule['columns']
         ]
     }

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -23,14 +23,14 @@ class TestIngestors(SimpleTestCase):
                     "dollars_budgeted"
                   ]
                 }
-        row_dict = OrderedDict([('category', 'red tape'), 
-                                ('dollars_budgeted', '2000'), 
+        row_dict = OrderedDict([('category', 'red tape'),
+                                ('dollars_budgeted', '2000'),
                                 ('dollars_spent', '2300')])
 
         exp_result = {
             'severity': 'Error',
             'code': None,
             'message': "spending should not exceed budget",
-            'error_columns': [ 'dollars_budgeted', 'dollars_spent']
+            'error_columns': ['dollars_budgeted', 'dollars_spent']
         }
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -1,0 +1,36 @@
+from collections import OrderedDict
+from data_ingest.ingestors import row_validation_error
+from django.test import SimpleTestCase
+
+
+class TestIngestors(SimpleTestCase):
+
+    def test_row_validation_error(self):
+        rule = {
+                  "code": {
+                    "<=": [
+                      {
+                        "var": "dollars_spent"
+                      },
+                      {
+                        "var": "dollars_budgeted"
+                      }
+                    ]
+                  },
+                  "message": "spending should not exceed budget",
+                  "columns": [
+                    "dollars_spent",
+                    "dollars_budgeted"
+                  ]
+                }
+        row_dict = OrderedDict([('category', 'red tape'), 
+                                ('dollars_budgeted', '2000'), 
+                                ('dollars_spent', '2300')])
+
+        exp_result = {
+            'severity': 'Error',
+            'code': None,
+            'message': "spending should not exceed budget",
+            'error_columns': [ 'dollars_budgeted', 'dollars_spent']
+        }
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)


### PR DESCRIPTION
This is to fix issue https://github.com/18F/django-data-ingest/issues/7.

## Changes
Keys (field names) will be returned when outputting "`error_columns` instead of index.