### PR TITLE
Cast CSV row values to their types in SQLValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ each user may submit multiple files.
 
 ## Requirements
 
-* Python (3.7)
+* Python (3.5, 3.6)
 * Django (1.11)
 * Goodtables
 * pyyaml

--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -97,9 +97,9 @@ def rows_from_source(raw_source):
 
     if byteslike:
         source['source'] = f_source
-        stream = tabulator.Stream(**source, encoding='utf-8')
+        stream = tabulator.Stream(**source)
     else:
-        stream = tabulator.Stream(source, headers=1, encoding='utf-8')
+        stream = tabulator.Stream(source, headers=1)
 
     stream.open()
     result = OrderedDict(
@@ -466,7 +466,6 @@ class Ingestor:
         stream = tabulator.Stream(
             io.BytesIO(self.upload.raw),
             format=self.upload.file_type,
-            encoding='utf-8',
             **UPLOAD_SETTINGS['STREAM_ARGS'])
         stream.open()
         if UPLOAD_SETTINGS['OLD_HEADER_ROW'] is not None:

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from data_ingest.ingestors import row_validation_error
+from data_ingest.ingestors import row_validation_error, SqlValidator
 from django.test import SimpleTestCase
 
 
@@ -34,3 +34,10 @@ class TestIngestors(SimpleTestCase):
             'error_columns': ['dollars_budgeted', 'dollars_spent']
         }
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+
+class TestSqlValidator(SimpleTestCase):
+    def test_cast_values(self):
+        self.assertEqual(SqlValidator.cast_values(
+            ("1", "3.4", "Test", "Number 1", "123 ")),
+            [1, 3.4, "Test", "Number 1", 123])


### PR DESCRIPTION
When reading CSV row, each cell/entry is treated as string.  This becomes a problem when we run the rules on these values because it will give different result than intended.  For example, 7 < 34 is True, but "7" < "34" is False because string will compare lexicographically.  This also fixes some of the potential problems of data that have extra spaces in them, etc.

## Additions:
- Added a new static method in SQLValidator to cast values for a row of values
- Tested this function

## Changes:
- Fixed the python version on README

