### PR TITLE
Space cannot be stripped if value is not a string

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -331,8 +331,9 @@ class SqlValidator(RowwiseValidator):
         # should be something defined in settings.py along with column names
         cvalues = []
         for val in row_values:
-            newval = val.strip()
+            newval = val
             if type(newval) == str:
+                newval = newval.strip()
                 if newval.isdigit():
                     newval = int(newval)
                 elif newval.replace('.', '', 1).isdigit():

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -38,7 +38,6 @@ class TestIngestors(SimpleTestCase):
 
 class TestSqlValidator(SimpleTestCase):
     def test_cast_values(self):
-        print("tst")
         self.assertEqual(SqlValidator.cast_values(
             ("1", "3.4", "Test", "Number 1", "123 ", 1, 2.05)),
             [1, 3.4, "Test", "Number 1", 123, 1, 2.05])

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -38,6 +38,7 @@ class TestIngestors(SimpleTestCase):
 
 class TestSqlValidator(SimpleTestCase):
     def test_cast_values(self):
+        print("tst")
         self.assertEqual(SqlValidator.cast_values(
-            ("1", "3.4", "Test", "Number 1", "123 ")),
-            [1, 3.4, "Test", "Number 1", 123])
+            ("1", "3.4", "Test", "Number 1", "123 ", 1, 2.05)),
+            [1, 3.4, "Test", "Number 1", 123, 1, 2.05])


### PR DESCRIPTION
An error occurred when a value is an integer, because integer doesn't have a `strip()` function.

## Changes:
- Moved the `strip()` method until value is confirmed to be a string
- Added test case to test integer and float numbers