### PR TITLE
Rewrite logic to convert string to numbers

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -7,6 +7,7 @@ import re
 import sqlite3
 import urllib.parse
 from collections import OrderedDict, defaultdict
+from decimal import Decimal, InvalidOperation
 
 import goodtables
 import json_logic
@@ -334,14 +335,21 @@ class SqlValidator(RowwiseValidator):
             newval = val
             if type(newval) == str:
                 newval = newval.strip()
-                if newval.isdigit():
-                    newval = int(newval)
-                elif newval.replace('.', '', 1).isdigit():
-                    newval = float(newval)
-                elif newval.replace(',', '').isdigit():
-                    newval = int(newval.replace(',', ''))
-                elif newval.replace(',', '').replace('.', '', 1).isdigit():
-                    newval = float(newval)
+                try:
+                    dnewval = Decimal(newval.replace(',', ''))
+                    try:
+                        inewval = int(dnewval)
+                        fnewval = float(dnewval)
+                        if inewval == fnewval:
+                            newval = inewval
+                        else:
+                            newval = fnewval
+                    except ValueError:
+                        # will take the newval.strip() as the value
+                        pass
+                except InvalidOperation:
+                    # will take the newval.strip() as the value
+                    pass
 
             cvalues.append(newval)
 

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -39,5 +39,5 @@ class TestIngestors(SimpleTestCase):
 class TestSqlValidator(SimpleTestCase):
     def test_cast_values(self):
         self.assertEqual(SqlValidator.cast_values(
-            ("1", "3.4", "Test", "Number 1", "123 ", 1, 2.05)),
-            [1, 3.4, "Test", "Number 1", 123, 1, 2.05])
+            ("1", "3.4", "Test", "Number 1", "123 ", 1, 2.05, "NaN", "2e3", "-12.0", "-4", "-12.45", "1,230,000")),
+            [1, 3.4, "Test", "Number 1", 123, 1, 2.05, "NaN", 2000, -12, -4, -12.45, 1230000])


### PR DESCRIPTION
The previous logic doesn't account for negative numbers, or other potential numbers written in a format with exponent.  Rewriting this logic to use Decimal class for the conversion and then convert back to int/float as appropriate.

## Changes:
- Rewrote `cast_values` logic to take into account more variety of numbers
- Added more test cases to check the logic