### PR TITLE
Encode incoming data to UTF-8 

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -98,9 +98,9 @@ def rows_from_source(raw_source):
 
     if byteslike:
         source['source'] = f_source
-        stream = tabulator.Stream(**source)
+        stream = tabulator.Stream(**source, encoding='utf-8')
     else:
-        stream = tabulator.Stream(source, headers=1)
+        stream = tabulator.Stream(source, headers=1, encoding='utf-8')
 
     stream.open()
     result = OrderedDict(
@@ -475,6 +475,7 @@ class Ingestor:
         stream = tabulator.Stream(
             io.BytesIO(self.upload.raw),
             format=self.upload.file_type,
+            encoding='utf-8',
             **UPLOAD_SETTINGS['STREAM_ARGS'])
         stream.open()
         if UPLOAD_SETTINGS['OLD_HEADER_ROW'] is not None:

--- a/data_ingest/urls.py
+++ b/data_ingest/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
         views.insert,
         name="insert",
     ),
-    url(r"^api/validate", api_views.validate),
+    url(r"^api/validate", api_views.validate, name="validate"),
     url(r"^api/", include(router.urls)),
     url(
         r"^",


### PR DESCRIPTION
We need to specify encoding to UTF-8 to make sure we can parse characters without errors that are in this range.

## Additions:
- Added encoding when we are parsing data
- Added name to url for easier testing reference

## Testing:
- Testing were done manually using data with characters with characters with ’