### PR TITLE
Gracefully treat case when empty data was sent over

### DIFF
--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -92,6 +92,10 @@ def to_tabular(incoming):
 
 def reorder_csv(incoming):
     data = incoming.copy()
+
+    if data.get('source') is None:
+        return data
+
     csvbuffer = io.StringIO(data['source'].decode('UTF-8'))
 
     output = io.StringIO()

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -91,10 +91,10 @@ def to_tabular(incoming):
 
 
 def reorder_csv(incoming):
-    data = incoming.copy()
+    if incoming.get('source') is None:
+        return incoming
 
-    if data.get('source') is None:
-        return data
+    data = incoming.copy()
 
     csvbuffer = io.StringIO(data['source'].decode('UTF-8'))
 

--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -95,7 +95,7 @@ def rows_from_source(raw_source):
     try:
         f_source = io.BytesIO(source['source'])
         byteslike = True
-    except (TypeError, AttributeError):
+    except (TypeError, AttributeError, KeyError):
         byteslike = False
 
     if byteslike:
@@ -107,7 +107,11 @@ def rows_from_source(raw_source):
     stream.open()
 
     # This will get the first row
-    hs = next(stream.iter(extended=True))[1]
+    try:
+        hs = next(stream.iter(extended=True))[1]
+    # nothing in the stream
+    except StopIteration:
+        hs = []
     # Reset the pointer to the beginning
     stream.reset()
     o_headers = get_ordered_headers(hs)

--- a/data_ingest/tests/test_api_views.py
+++ b/data_ingest/tests/test_api_views.py
@@ -33,6 +33,9 @@ class TestReorderCSV(SimpleTestCase):
         data = {'source': b'a,b,c\n1,2,3\n4,5,6\n'}
         self.assertEqual({'source': b'c,a,b\n3,1,2\n6,4,5\n'}, reorder_csv(data))
 
+        data = {}
+        self.assertEqual({}, reorder_csv(data))
+
         data = {'source': b''}
         self.assertEqual({'source': b''}, reorder_csv(data))
 


### PR DESCRIPTION
In case data coming in is empty, to prevent it from crashing, this will handle it gracefully:

## Additions:
- Return empty data without performing action to it
- Catch exception when data is empty, so it doesn't perform action on it

## Tests:
- Tests were done using USDA FNS Validation Service, and the error was revealed there
- Added test for `reorder_csv`
- tests were not written on `ingestors.py`, it will be done at a later time when refactor