### PR TITLE
Evaluate variables in Error Message

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -288,14 +288,30 @@ def row_validation_error(rule, row_dict):
                 # If they are all supported type, then this expression can be evaluated
                 if any(isinstance(value1, t) for t in supported_type) and \
                    any(isinstance(value2, t) for t in supported_type):
-                    # Only using a controlled set of operations here, the operation is
-                    # well-examined to know it doesn't create any security issue
-                    result = eval(f'{value1} {operator} {value2}')
+                    # Right now being super explicit about which operator we support
+                    if operator == '+':
+                        result = f'{value1 + value2}'
+                    elif operator == '-':
+                        result = f'{value1 - value2}'
+                    elif operator == '*':
+                        result = f'{value1 * value2}'
+                    elif operator == '/':
+                        result = f'{value1 / value2}'
+                    else:
+                        # it really shouldn't have gotten here because we are only matching the allowed operation above
+                        raise UnsupportedException()
+
+                    # Will only use this when we are very sure there is no issue
+                    # result = eval(f'{value1} {operator} {value2}')
+
                     message = message.replace(field, str(result))
 
             except (KeyError, AttributeError):
                 # This means the expression is malformed or key are misspelled
                 message = f"Unable to evaluate {field}"
+                break
+            except UnsupportedException:
+                message = f"Unsupported operation in {field}"
                 break
 
     error['message'] = message

--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -1,4 +1,3 @@
-import ast
 import csv
 import io
 import json

--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -294,12 +294,11 @@ def row_validation_error(rule, row_dict):
                     message = message.replace(field, str(result))
 
             except (KeyError, AttributeError):
-                # This means the expression is malformed, will not replace field with anything
+                # This means the expression is malformed or key are misspelled
                 message = f"Unable to evaluate {field}"
                 break
 
     error['message'] = message
-    # error['message'] = rule.get('message', '').format(**row_dict)
 
     return error
 

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -47,9 +47,10 @@ class TestIngestors(SimpleTestCase):
                       }
                     ]
                   },
-                  "message": "{category_misspelled}: spent/budget: {dollars_spent/ dollars_budgeted} spent+budget: " +
+                  "message": "{category}: spent/budget: {dollars_spent/ dollars_budgeted} spent+budget: " +
                              "{dollars_spent+dollars_budgeted} spent-budget: {dollars_spent-dollars_budgeted} " +
-                             "spent*budget: {dollars_spent*dollars_budgeted} {d/b}",
+                             "spent*budget: {dollars_spent*dollars_budgeted} spent + 4: {dollars_spent + 4} " +
+                             "20.56 * budget: {20.56 * dollars_budgeted}",
                   "columns": [
                     "dollars_spent",
                     "dollars_budgeted"
@@ -62,10 +63,14 @@ class TestIngestors(SimpleTestCase):
         exp_result = {
             'severity': 'Error',
             'code': None,
-            'message': "{category_misspelled}: spent/budget: 1.15 spent+budget: 4300 spent-budget: 300 spent*budget: " +
-                       "4600000 {d/b}",
+            'message': "red tape: spent/budget: 1.15 spent+budget: 4300 spent-budget: 300 spent*budget: " +
+                       "4600000 spent + 4: 2304 20.56 * budget: 41120.0",
             'error_columns': ['dollars_budgeted', 'dollars_spent']
         }
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+        rule["message"] = "{d/b} {category}"
+        exp_result["message"] = 'Unable to evaluate {d/b}'
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)
 
 

--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from data_ingest.ingestors import row_validation_error, SqlValidator
+from data_ingest.ingestors import row_validation_error, RowwiseValidator
 from django.test import SimpleTestCase
 
 
@@ -35,9 +35,42 @@ class TestIngestors(SimpleTestCase):
         }
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)
 
+    def test_row_validation_error_message(self):
+        rule = {
+                  "code": {
+                    "<=": [
+                      {
+                        "var": "dollars_spent"
+                      },
+                      {
+                        "var": "dollars_budgeted"
+                      }
+                    ]
+                  },
+                  "message": "{category_misspelled}: spent/budget: {dollars_spent/ dollars_budgeted} spent+budget: " +
+                             "{dollars_spent+dollars_budgeted} spent-budget: {dollars_spent-dollars_budgeted} " +
+                             "spent*budget: {dollars_spent*dollars_budgeted} {d/b}",
+                  "columns": [
+                    "dollars_spent",
+                    "dollars_budgeted"
+                  ]
+                }
+        row_dict = OrderedDict([('category', 'red tape'),
+                                ('dollars_budgeted', '2000'),
+                                ('dollars_spent', '2300')])
 
-class TestSqlValidator(SimpleTestCase):
+        exp_result = {
+            'severity': 'Error',
+            'code': None,
+            'message': "{category_misspelled}: spent/budget: 1.15 spent+budget: 4300 spent-budget: 300 spent*budget: " +
+                       "4600000 {d/b}",
+            'error_columns': ['dollars_budgeted', 'dollars_spent']
+        }
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+
+class TestRowwiseValidator(SimpleTestCase):
     def test_cast_values(self):
-        self.assertEqual(SqlValidator.cast_values(
+        self.assertEqual(RowwiseValidator.cast_values(
             ("1", "3.4", "Test", "Number 1", "123 ", 1, 2.05, "NaN", "2e3", "-12.0", "-4", "-12.45", "1,230,000")),
             [1, 3.4, "Test", "Number 1", 123, 1, 2.05, "NaN", 2000, -12, -4, -12.45, 1230000])


### PR DESCRIPTION
This PR is to implement this: https://github.com/18F/data-federation-project/issues/110

## Additions
- Support doing simple operations on two variables or with numeric in an error message (+, -, *, /)

## Changes
- Moved `cast_values` up to the parent `RowwiseValidator`, and broke out the function to allow casting only one value `cast_value`

## Tests
- Added tests to test out these simple operations in error message
- Performed some manual tests using USDA FNS Validation Services to ensure it works there