### PR TITLE
Precision for Error Messages

### DIFF
--- a/data_ingest/tests/test_ingestors.py
+++ b/data_ingest/tests/test_ingestors.py
@@ -50,7 +50,7 @@ class TestIngestors(SimpleTestCase):
                   "message": "{category}: spent/budget: {dollars_spent/ dollars_budgeted} spent+budget: " +
                              "{dollars_spent+dollars_budgeted} spent-budget: {dollars_spent-dollars_budgeted} " +
                              "spent*budget: {dollars_spent*dollars_budgeted} spent + 4: {dollars_spent + 4} " +
-                             "20.56 * budget: {20.56 * dollars_budgeted}",
+                             "20.56 * budget: {20.56 * dollars_budgeted} 12.56 / budget: {12.56 / dollars_budgeted:4}",
                   "columns": [
                     "dollars_spent",
                     "dollars_budgeted"
@@ -64,13 +64,29 @@ class TestIngestors(SimpleTestCase):
             'severity': 'Error',
             'code': None,
             'message': "red tape: spent/budget: 1.15 spent+budget: 4300 spent-budget: 300 spent*budget: " +
-                       "4600000 spent + 4: 2304 20.56 * budget: 41120.0",
+                       "4600000 spent + 4: 2304 20.56 * budget: 41120.0 12.56 / budget: 0.0063",
             'error_columns': ['dollars_budgeted', 'dollars_spent']
         }
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)
 
         rule["message"] = "{d/b} {category}"
         exp_result["message"] = 'Unable to evaluate {d/b}'
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+        rule["message"] = "{dollars_budgeted/dollars_spent:}"
+        exp_result["message"] = 'Unable to evaluate {dollars_budgeted/dollars_spent:}'
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+        rule["message"] = "{dollars_spent/dollars_budgeted 123}"
+        exp_result["message"] = 'Unable to evaluate {dollars_spent/dollars_budgeted 123}'
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+        rule["message"] = "{dollars_spent/dollars_budgeted :12}"
+        exp_result["message"] = 'Unable to evaluate {dollars_spent/dollars_budgeted :12}'
+        self.assertEqual(row_validation_error(rule, row_dict), exp_result)
+
+        rule["message"] = "{dollars_spent/dollars_budgeted:category}"
+        exp_result["message"] = 'Unable to evaluate {dollars_spent/dollars_budgeted:category}'
         self.assertEqual(row_validation_error(rule, row_dict), exp_result)
 
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -54,6 +54,17 @@ These rules may look like
 - `code`: An expression in the appropriate language (such as SQL or JsonLogic)
 - `message`: Text to display to submitter when a row violates this rule.
 
+#### Messages
+
+Messages also support the use of simple string interpolation.  Anything that is included
+inside the curly brackets `{}` will be evaluated and replaced by its value.
+- `{column}`: By putting the column name inside the curly brackets, this will be replaced
+  with the actual value of this row's column.
+- `{A op B}`: `A` is a column name or a number (integer or decimal number), `op` is an arithmetic
+  operator `+`, `-`, `*` or `/`, and `B` is a column name or a number (integer or decimal number).
+- `{A op B:C}`: `A op B` is the same as above, `C` is the number of decimal places to display
+  after the decimal.
+
 ### Optional fields 
 
 - `error_code`: A user-defined code for this rule


### PR DESCRIPTION
This support the use of precision for error messages.  By supplying the number of decimal places after the decimal, the value of the string interpolation will be formatted accordingly.

## Addition:
- Added a new spec for including precision, which is a `:number` after the operation in the string interpolation
- Added documentation to explain this new feature

## Tests:
- Tests are added for this new change