### PR TITLE
Template swap fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .vscode
 .DS_store
 
+# vim
+*.swp
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/data_ingest/templates/data_ingest/review-errors.html
+++ b/data_ingest/templates/data_ingest/review-errors.html
@@ -1,4 +1,5 @@
 {% extends 'data_ingest/base.html' %}
+{% load get_key %}
 {% block content %}
 
 <div class="usa-grid" style="overflow: auto">
@@ -54,7 +55,7 @@
             <td>{{ err.message }}</td>
             {% for h in headers %}
             <td {% if h in err.error_columns %} class="bad-value" style="color:red;" {% endif %}
-            >{{ row.data | get_item:h }}</td>
+            >{{ row.data | get_key:h }}</td>
 
             {% endfor %}
           </tr>

--- a/data_ingest/templates/data_ingest/review-errors.html
+++ b/data_ingest/templates/data_ingest/review-errors.html
@@ -41,9 +41,9 @@
         <thead>
             <th>Row #</th><th>Severity</th></th><th>Error code</th><th>message</th>
           {% for h in headers %}
-            <th>{{ forloop.counter }} : {{ h }}</th>
+            <th>{{ h }}</th>
           {% endfor %}
-        </thead
+        </thead>
         <tbody>
         {% for row in rows %}
           {% for err in row.errors %}
@@ -52,9 +52,9 @@
             <td>{{ err.severity }}</td>
             <td>{{ err.code }}</td>
             <td>{{ err.message }}</td>
-            {% for itm in row.data.values %}
-            <td {% if forloop.counter0 in err.error_columns %} class="bad-value" style="color:red;" {% endif %}
-            >{{ itm }}</td>
+            {% for h in headers %}
+            <td {% if h in err.error_columns %} class="bad-value" style="color:red;" {% endif %}
+            >{{ row.data | get_item:h }}</td>
 
             {% endfor %}
           </tr>

--- a/data_ingest/templates/data_ingest/review-errors.html
+++ b/data_ingest/templates/data_ingest/review-errors.html
@@ -1,5 +1,5 @@
 {% extends 'data_ingest/base.html' %}
-{% load get_key %}
+{% load get_value %}
 {% block content %}
 
 <div class="usa-grid" style="overflow: auto">
@@ -55,7 +55,7 @@
             <td>{{ err.message }}</td>
             {% for h in headers %}
             <td {% if h in err.error_columns %} class="bad-value" style="color:red;" {% endif %}
-            >{{ row.data | get_key:h }}</td>
+            >{{ row.data | get_value:h }}</td>
 
             {% endfor %}
           </tr>

--- a/data_ingest/templatetags/get_key.py
+++ b/data_ingest/templatetags/get_key.py
@@ -1,0 +1,8 @@
+from django import template
+
+
+register = template.Library()
+
+@register.filter
+def get_key(dictionary, key):
+    return dictionary.get(key)

--- a/data_ingest/templatetags/get_value.py
+++ b/data_ingest/templatetags/get_value.py
@@ -4,5 +4,5 @@ from django import template
 register = template.Library()
 
 @register.filter
-def get_key(dictionary, key):
+def get_value(dictionary, key):
     return dictionary.get(key)

--- a/data_ingest/views.py
+++ b/data_ingest/views.py
@@ -112,12 +112,6 @@ def upload(request, replace_upload_id=None, **kwargs):
                   {"form": form})
 
 
-# left import here for ease-of-movement
-# since i suspect this is not the right place
-from django.template.defaulttags import register
-@register.filter
-def get_item(dictionary, key):
-    return dictionary.get(key)
 
 def review_errors(request, upload_id):
     upload = UploadModel.objects.get(pk=upload_id)

--- a/data_ingest/views.py
+++ b/data_ingest/views.py
@@ -112,6 +112,13 @@ def upload(request, replace_upload_id=None, **kwargs):
                   {"form": form})
 
 
+# left import here for ease-of-movement
+# since i suspect this is not the right place
+from django.template.defaulttags import register
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)
+
 def review_errors(request, upload_id):
     upload = UploadModel.objects.get(pk=upload_id)
     if upload.validation_results['valid']:


### PR DESCRIPTION
This will fix https://github.com/18F/django-data-ingest/issues/27. I'm not sure about whether it would respect any column swapping that gets done (that's not a piece I fully understand yet in general, but sounds like it's more tied to the API currently)... but it does make sure that whatever ordering gets passed in to the template as the `headers` variable, that ordering remains respected.

As a side effect, it also was easy to fix the error-ing cells not showing up in red by changing to a key-based lookup.