### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,23 @@ each user may submit multiple files.
 
 ---
 
-## Installation
+## Quick Installation
 
-Install using `pipenv`...
+If you would like to use `django-data-ingest` in your Django project, install using `pipenv` in your project...
+
+- Replace `<version>` with the latest tag i.e. `v0.2` or
+- Replace with `master` if you would like to work with the latest development version
 
 ```bash
-pipenv install django-data-ingest
+pipenv install -e git+https://github.com/18F/django-data-ingest.git@<version>#egg=django-data-ingest
 ```
 
-Add `'data_ingest'` to your `INSTALLED_APPS` setting.
+Add `'rest_framework'`, and `'data_ingest'` to your `INSTALLED_APPS` setting.
 
 ```python
 INSTALLED_APPS = (
     ...
+    'rest_framework',
     'data_ingest',
 )
 ```
@@ -75,6 +79,11 @@ Follow the [development](#development) instructions to close this repository and
 To perform data validation with API, see [API documentation](docs/api.md).
 
 ---
+
+## Deployment on Cloud.gov
+
+All of the examples provided will show you how to run them locally.  If you are interested in using [cloud.gov](https://cloud.gov) as your platform, here's a [basic installation guide on cloud.gov deployment](docs/cloud.gov.md).
+
 
 ## Contributing
 

--- a/docs/cloud.gov.md
+++ b/docs/cloud.gov.md
@@ -1,0 +1,69 @@
+# Cloud.gov setup
+
+If you would like to deploy your project to [cloud.gov](https://cloud.gov/), here's a quick installation guide.  Please note that this is an example of how you can deploy to [cloud.gov](https://cloud.gov/).  There are other ways that may fit better for your deployment pipeline.  Please refer to [cloud.gov documentation](https://cloud.gov/docs/) for other ways.
+
+In your `<myproject>/settings.py`:
+
+- Use the following `DATABASE`, and replace `myprojectdb` with the name of your database.
+
+```python
+import dj_database_url
+
+DATABASES = {'default': dj_database_url.config(
+    default='postgres:///myprojectdb')}
+```
+
+- Add `ALLOWED_HOST`.
+```python
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    '.cloud.gov',
+]
+```
+
+- Specify the `STATIC_ROOT`.
+
+```python
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+```
+
+Generate a `requirements.txt` file from the `Pipfile.lock` in your base directory.  Run the following from the shell in your base directory.
+
+```bash
+pipenv lock -r > requirements.txt
+```
+
+Specify the version of python you are running in a `runtime.txt` file in your base directory.  In our case, we are running 3.6.
+```bash
+python-3.6.x
+```
+
+Create a `manifest.yml` file in your base directory.  Replace the `application-name` with the application name you would like to deploy to, and `myprojectdb` with the database name you are using.
+```yml
+applications:
+- name: application-name
+  services:
+   - myprojectdb
+```
+
+Create a `run.sh` file in your base directory with the following information.  The arguments of `create_user` method is the username, email address, and password respectively.  You can make use of environment variables for each of these arguments to prevent exposing these information.  Please **do not** post these information publicly.
+```bash
+python manage.py migrate
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user('user1', 'user1@example.gov', 'password')"
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user('user2', 'user2@example.gov', 'password')"
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user('user3', 'user3@example.gov', 'password')"
+```
+
+Create a `Procfile` file in your base directory with the following information.  This file will run when deployed.
+```bash
+web: ./run.sh
+```
+
+On cloud.gov, you will need to create a service instance for your database, which will be a psql service.  For more information on how to do it, refer to [managed services documentation](https://cloud.gov/docs/apps/managed-services/).
+
+Once everything is in place, you can push the application to cloud.gov.  You will first need to log into cloud.gov and go to your org and space.  If you ever need to re-deploy your application, you can also use this command from your base directory, and replace `application-name` with your application name in your `manifest.yml` file.  See [deployment documentation](https://cloud.gov/docs/apps/deployment/) on cloud.gov for more details.
+
+```bash
+cf push application-name
+```

--- a/docs/default.md
+++ b/docs/default.md
@@ -6,13 +6,23 @@ An example is available at [examples/defaults](../examples/defaults.md)
 
 ## Creating the minimal project
 
-Install `data ingest`
+Create a folder for your Django project name (replace `myproject` with the project name) and go into the folder:
+```bash
+mkdir myproject
+cd myproject
+```
 
-    pipenv install -e git+https://github.com/18F/django-data-ingest.git@master#egg=django-data-ingest
+Install `django-data-ingest`:
+- Replace `<version>` with the latest tag i.e. `v0.2` or
+- Replace with `master` if you would like to work with the latest development version
+```bash
+    pipenv install -e git+https://github.com/18F/django-data-ingest.git@<version>#egg=django-data-ingest
+```
 
-Begin your Django project as usual.  Replace `<myproject>` with the name of your project.
-
-    django-admin.py startproject myproject
+Begin your Django project as usual.  Replace `myproject` with the name of your project.  This will create your Django project in the current directory
+```bash
+    django-admin.py startproject myproject .
+```
 
 In `myproject/settings.py`, add `rest_framework` and `data_ingest` to `INSTALLED_APPS`.
 
@@ -28,7 +38,7 @@ INSTALLED_APPS = [
     'data_ingest',
 ]
 ```
-Also in `<myproject>/settings.py`, change the `DATABASE` settings to a PostgreSQL database.  Replace `myprojectdb` with the name of your database.
+Also in `myproject/settings.py`, change the `DATABASE` settings to a PostgreSQL database.  Replace `myprojectdb` with the name of your database.
 
 ```python
 DATABASES = {
@@ -75,7 +85,8 @@ CSV files.
 
 ## To run on Cloud.gov
 
-Please following [cloud.gov deployment instruction](cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](cloud.gov.md)
+
 
 ## Default behavior
 

--- a/docs/default.md
+++ b/docs/default.md
@@ -85,7 +85,7 @@ CSV files.
 
 ## To run on Cloud.gov
 
-Please follow the [cloud.gov deployment instruction](cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](cloud.gov.md).
 
 
 ## Default behavior

--- a/docs/default.md
+++ b/docs/default.md
@@ -6,79 +6,80 @@ An example is available at [examples/defaults](../examples/defaults.md)
 
 ## Creating the minimal project
 
-Install Django 1.11.
+Install `data ingest`
 
-    pipenv install django==1.11
+    pipenv install -e git+https://github.com/18F/django-data-ingest.git@master#egg=django-data-ingest
 
-Begin your Django project as usual.
+Begin your Django project as usual.  Replace `<myproject>` with the name of your project.
 
     django-admin.py startproject myproject
 
-In `myproject/settings.py`, add `data_ingest'` to `INSTALLED_APPS`.
+In `myproject/settings.py`, add `rest_framework` and `data_ingest` to `INSTALLED_APPS`.
 
-    INSTALLED_APPS = [
-        'django.contrib.admin',
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.sessions',
-        'django.contrib.messages',
-        'django.contrib.staticfiles',
-        'data_ingest',
-    ]
+```python
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'data_ingest',
+]
+```
+Also in `<myproject>/settings.py`, change the `DATABASE` settings to a PostgreSQL database.  Replace `myprojectdb` with the name of your database.
 
-Also in `myproject/settings.py`, change the `DATABASE` settings to a PostgreSQL database.
-
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'myprojectdb',
-        }
+```python
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'myprojectdb',
     }
-
-Or (recommended, especially if you are deploying to cloud.gov),
-
-    import dj_database_url
-
-    DATABASES = {'default': dj_database_url.config(
-        default='postgres:///myprojectdb')}
-
+}
+```
 
 Add the data_ingest urls and a login url to `myproject/urls.py`.
 
-    from django.conf.urls import url, include
-    from django.contrib import admin
-    import data_ingest.urls
+```python
+from django.conf.urls import url, include
+from django.contrib import admin
+import data_ingest.urls
 
-    urlpatterns = [
-        url(r'^admin/', admin.site.urls),
-        url(r'^data_ingest/', include(data_ingest.urls)),
-        url('accounts/', include('django.contrib.auth.urls')),
-    ]
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'^data_ingest/', include(data_ingest.urls)),
+    url('accounts/', include('django.contrib.auth.urls')),
+]
+```
+
+## To run locally
 
 Create a PostgreSQL database with the name you used, run the inital migrations, and
 create a user account.
 
-    createdb myprojectdb
-    python manage.py migrate
-    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
-        'chris', 'chris@gsa.gov', 'publicservice')"
-
+```bash
+createdb myprojectdb
+python manage.py migrate
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
+    'chris', 'chris@gsa.gov', 'publicservice')"
+```
 Run the server.
 
-    python manage.py runserver
+```bash
+python manage.py runserver
+```
 
 Visit http://localhost:8000/data_ingest/, login with the account you created, and try uploading some
 CSV files.
 
+## To run on Cloud.gov
+
+Please following [cloud.gov deployment instruction](cloud.gov.md)
 
 ## Default behavior
 
 - No metadata is added to the files.  ([To change](customize.md))
 - The only validation applied is [Goodtables](http://goodtables.okfnlabs.org/)' default validator.  This simply ensures that a CSV has a fundamentally valid form.  ([To change](customize.md))
 - Inserting files saves the data as JSON files in a `data_ingest/` directory under the project directory.  ([To change](customize.md))
-
-- ([To change](customize.md))
-- ([To change](customize.md))
-- ([To change](customize.md))
-- ([To change](customize.md))
 

--- a/docs/examples/default.md
+++ b/docs/examples/default.md
@@ -25,4 +25,4 @@ some CSVs (like the provided [example](../../examples/defaults/staff.csv)).
 
 ## To run on Cloud.gov
 
-Please follow the [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md).

--- a/docs/examples/default.md
+++ b/docs/examples/default.md
@@ -22,3 +22,7 @@ Run the server.
 
 Visit http://localhost:8000/data_ingest/, login as `chris/publicservice`, and try uploading
 some CSVs (like the provided [example](../../examples/defaults/staff.csv)).
+
+## To run on Cloud.gov
+
+Please following [cloud.gov deployment instruction](../cloud.gov.md)

--- a/docs/examples/default.md
+++ b/docs/examples/default.md
@@ -25,4 +25,4 @@ some CSVs (like the provided [example](../../examples/defaults/staff.csv)).
 
 ## To run on Cloud.gov
 
-Please following [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/defaults/README.md
+++ b/examples/defaults/README.md
@@ -25,4 +25,4 @@ some CSVs (like the provided [example](staff.csv)).
 
 ## To run on Cloud.gov
 
-Please follow the [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md).

--- a/examples/defaults/README.md
+++ b/examples/defaults/README.md
@@ -25,4 +25,4 @@ some CSVs (like the provided [example](staff.csv)).
 
 ## To run on Cloud.gov
 
-Please following [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/defaults/README.md
+++ b/examples/defaults/README.md
@@ -22,3 +22,7 @@ Run the server.
 
 Visit http://localhost:8000/data_ingest/, login as `chris/publicservice`, and try uploading
 some CSVs (like the provided [example](staff.csv)).
+
+## To run on Cloud.gov
+
+Please following [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/p02_budgets/README.md
+++ b/examples/p02_budgets/README.md
@@ -89,4 +89,4 @@ some CSVs (like the provided [example](b01.csv)).
 
 ## To run on Cloud.gov
 
-Please following [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/p02_budgets/README.md
+++ b/examples/p02_budgets/README.md
@@ -15,7 +15,7 @@ Demonstrates `data_ingest` with some basic [customizations](../../docs/customize
 
 ## Configuring the project
 
-Mostly, the project was created like the [default one](default.md), with these
+Mostly, the project was created like the [default one](../defaults/README.md), with these
 exceptions:
 
 - Created a `budget_data_ingest` project:
@@ -40,44 +40,53 @@ exceptions:
 
 - Additions/edits to `p02_budget/settings.py`:
 
-    INSTALLED_APPS = [
-        'django.contrib.admin',
-        ...
-        'budget_data_ingest',
-        'data_ingest',
-    ]
+```python
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    ...
+    'budget_data_ingest',
+    'data_ingest',
+]
 
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'budget_ingestor',
-        }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'budget_ingestor',
     }
+}
 
-    DATA_INGEST = {
-        'MODEL': 'budget_data_ingest.models.Upload',
-        'FORM': 'budget_data_ingest.forms.UploadForm',
-        'DESTINATION': 'budget_data_ingest.models.BudgetItem',
-        'VALIDATORS': {
-            'table_schema.json': 'data_ingest.ingestors.GoodtablesValidator',
-            'json_logic.json': 'data_ingest.ingestors.JsonlogicValidator',
-            'sql_rules.json': 'data_ingest.ingestors.SqlValidator',
-        },       
-    }
-
+DATA_INGEST = {
+    'MODEL': 'budget_data_ingest.models.Upload',
+    'FORM': 'budget_data_ingest.forms.UploadForm',
+    'DESTINATION': 'budget_data_ingest.models.BudgetItem',
+    'VALIDATORS': {
+        'table_schema.json': 'data_ingest.ingestors.GoodtablesValidator',
+        'json_logic.json': 'data_ingest.ingestors.JsonlogicValidator',
+        'sql_rules.json': 'data_ingest.ingestors.SqlValidator',
+    },
+}
+```
 ## To run locally
 
 Create a PostgreSQL database named `budget_ingestor`, run the inital migrations, and
 create a user account.
 
-    createdb budget_ingestor
-    python manage.py migrate
-    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
-        'chris', 'chris@gsa.gov', 'publicservice')"
+```bash
+createdb budget_ingestor
+python manage.py migrate
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
+    'chris', 'chris@gsa.gov', 'publicservice')"
+```
 
 Run the server.
 
-    python manage.py runserver
+```bash
+python manage.py runserver
+```
 
 Visit http://localhost:8000/data_ingest/, login as `chris/publicservice`, and try uploading
 some CSVs (like the provided [example](b01.csv)).
+
+## To run on Cloud.gov
+
+Please following [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/p02_budgets/README.md
+++ b/examples/p02_budgets/README.md
@@ -89,4 +89,4 @@ some CSVs (like the provided [example](b01.csv)).
 
 ## To run on Cloud.gov
 
-Please follow the [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md).

--- a/examples/p03_budgets/README.md
+++ b/examples/p03_budgets/README.md
@@ -54,4 +54,4 @@ some CSVs (like the provided [example](budget.csv)).
 
 ## To run on Cloud.gov
 
-Please follow the [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md).

--- a/examples/p03_budgets/README.md
+++ b/examples/p03_budgets/README.md
@@ -54,4 +54,4 @@ some CSVs (like the provided [example](budget.csv)).
 
 ## To run on Cloud.gov
 
-Please following [cloud.gov deployment instruction](../cloud.gov.md)
+Please follow the [cloud.gov deployment instruction](../cloud.gov.md)

--- a/examples/p03_budgets/README.md
+++ b/examples/p03_budgets/README.md
@@ -11,7 +11,7 @@ Demonstrates `data_ingest` with some more advanced [customizations](../../docs/c
 
 ## Configuring the project
 
-Mostly, the project was created like the [default one](default.md), with these
+Mostly, the project was created like the [default one](../defaults/README.md), with these
 additions/exceptions:
 
 - Subclass `Ingestor` in [`budget_data_ingest/ingestors.py`](budget_data_ingest/ingestors.py)
@@ -19,6 +19,7 @@ additions/exceptions:
   
 - Additions to `p03_budget/settings.py`:
 
+```python
 DATA_INGEST = {
     'INGESTOR': 'budget_data_ingest.ingestors.Ingestor',
     'DESTINATION_FORMAT': 'tsv',
@@ -28,20 +29,29 @@ DATA_INGEST = {
     },
     'OLD_HEADER_ROW': 1,
 }
+```
 
 ## To run locally
 
 Create a PostgreSQL database named `budget_ingestor`, run the inital migrations, and
 create a user account.
 
+```bash
     createdb p03_budget_ingestor
     python manage.py migrate
     python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
         'chris', 'chris@gsa.gov', 'publicservice')"
+```
 
 Run the server.
 
+```bash
     python manage.py runserver
+```
 
 Visit http://localhost:8000/data_ingest/, login as `chris/publicservice`, and try uploading
 some CSVs (like the provided [example](budget.csv)).
+
+## To run on Cloud.gov
+
+Please following [cloud.gov deployment instruction](../cloud.gov.md)

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ setup(
     license='CC0-1.0',
     description='Django app to upload, validate, review, and accept data files',
     long_description=README,
-    url='https://github.com/18F/data-federation-ingest',
+    url='https://github.com/18F/django-data-ingest',
     author='18F',
-    author_email='catherine.devlin@gsa.gov',
+    author_email='data-federation@gsa.gov',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
Documentation has some outdated information on how to install and run.  Updating them to reflect the new instruction.

## Additions:
- Added instruction on cloud.gov deployment
- Added language specifiers for all code snippets

## Changes:
- Consolidated all cloud.gov deployment instructions into `cloud.gov.md`
- Fixed project name and email address in `setup.py`

## Notes:
- This is the first pass of the documentation, and there are still some duplications in the documentation that may need to be cleaned up.