### PR TITLE
Change version to 0.3 to prepare for a snapshot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-data-ingest',
-    version='0.2',
+    version='0.3',
     packages=find_packages(),
     include_package_data=True,
     license='CC0-1.0',


### PR DESCRIPTION
Would like to create a snapshot before we roll in a more dramatic change with a new validator where we change some of the interfaces.