### PR TITLE
Add token authentication for `validate` endpoint

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: .venv
+exclude: .venv,tests

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -79,10 +79,10 @@
         },
         "datapackage": {
             "hashes": [
-                "sha256:d08e9c21865c99a0bb3f469c36c5fd5c00c7abc391a484494475ecf8773f2405",
-                "sha256:d4691774ec41e3b643ed863d8f051b10737d3b3bf995dc9449983271418c1c41"
+                "sha256:0781ce8f203e962cdc0d9440f16940b36aafbce57b6a1c64bcb0f81ce48d87fb",
+                "sha256:b78e02ec0976e8a965329ecb5b0ebafbde07ece901e2db37064a68a888970a88"
             ],
-            "version": "==1.7.0"
+            "version": "==1.9.0"
         },
         "dj-database-url": {
             "hashes": [
@@ -94,11 +94,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:52a66d7f8b036d02da0a4472359e8be1727424fc1e4b4f5c684ef97de7b569e1",
-                "sha256:c85b8c95366e187ca0581d45a6e508107ca4bd38cb45c24aa09d3572074c523d"
+                "sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3",
+                "sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3"
             ],
             "index": "pypi",
-            "version": "==1.11.23"
+            "version": "==1.11.24"
         },
         "djangorestframework": {
             "hashes": [
@@ -312,9 +312,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0459bf0ea6478f3e904de074d65769a11d74cdc34438ab3159250c96d089aef0"
+                "sha256:2f8ff566a4d3a92246d367f2e9cd6ed3edeef670dcd6dda6dfdc9efed88bcd80"
             ],
-            "version": "==1.3.7"
+            "version": "==1.3.8"
         },
         "statistics": {
             "hashes": [
@@ -324,17 +324,17 @@
         },
         "tableschema": {
             "hashes": [
-                "sha256:04975fa0fa7c5d817417764b11231db06cedb798fdf1f35845b5926da197a0d8",
-                "sha256:ac75b847634bc3c0b21013f11dfd9db71bb4cc44be4ce2e6b8e3a7ab6839bc58"
+                "sha256:a55747eee03fd7fcd01d21cc0b8680124c8fa9d91685dbc674370970b20476cb",
+                "sha256:ef8745197a2d74b87d0f4358d9d1b3877b55e70e88d4649f9011b9e45835b528"
             ],
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "tabulator": {
             "hashes": [
-                "sha256:48b8d0facfb9cdb2f030c634248b1a4f9533ca08e630ab33fafdaff44f8e0475",
-                "sha256:a7a9b7d60a6e042b200b3821ecfdfbde82dab54c9b04dc7fc83a9184aa2065d0"
+                "sha256:7c923ebdf007dbc8269d065014487c1692b7a092427cca1343353a842d37f0c1",
+                "sha256:b69c14dcfb46fc7965fb3d5f88f058dc12e2b8dc58a3e6aa2f408750fa2d83bf"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "unicodecsv": {
             "hashes": [
@@ -477,10 +477,10 @@
         },
         "datapackage": {
             "hashes": [
-                "sha256:d08e9c21865c99a0bb3f469c36c5fd5c00c7abc391a484494475ecf8773f2405",
-                "sha256:d4691774ec41e3b643ed863d8f051b10737d3b3bf995dc9449983271418c1c41"
+                "sha256:0781ce8f203e962cdc0d9440f16940b36aafbce57b6a1c64bcb0f81ce48d87fb",
+                "sha256:b78e02ec0976e8a965329ecb5b0ebafbde07ece901e2db37064a68a888970a88"
             ],
-            "version": "==1.7.0"
+            "version": "==1.9.0"
         },
         "dj-database-url": {
             "hashes": [
@@ -492,11 +492,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:52a66d7f8b036d02da0a4472359e8be1727424fc1e4b4f5c684ef97de7b569e1",
-                "sha256:c85b8c95366e187ca0581d45a6e508107ca4bd38cb45c24aa09d3572074c523d"
+                "sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3",
+                "sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3"
             ],
             "index": "pypi",
-            "version": "==1.11.23"
+            "version": "==1.11.24"
         },
         "djangorestframework": {
             "hashes": [
@@ -778,9 +778,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0459bf0ea6478f3e904de074d65769a11d74cdc34438ab3159250c96d089aef0"
+                "sha256:2f8ff566a4d3a92246d367f2e9cd6ed3edeef670dcd6dda6dfdc9efed88bcd80"
             ],
-            "version": "==1.3.7"
+            "version": "==1.3.8"
         },
         "statistics": {
             "hashes": [
@@ -797,17 +797,17 @@
         },
         "tableschema": {
             "hashes": [
-                "sha256:04975fa0fa7c5d817417764b11231db06cedb798fdf1f35845b5926da197a0d8",
-                "sha256:ac75b847634bc3c0b21013f11dfd9db71bb4cc44be4ce2e6b8e3a7ab6839bc58"
+                "sha256:a55747eee03fd7fcd01d21cc0b8680124c8fa9d91685dbc674370970b20476cb",
+                "sha256:ef8745197a2d74b87d0f4358d9d1b3877b55e70e88d4649f9011b9e45835b528"
             ],
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "tabulator": {
             "hashes": [
-                "sha256:48b8d0facfb9cdb2f030c634248b1a4f9533ca08e630ab33fafdaff44f8e0475",
-                "sha256:a7a9b7d60a6e042b200b3821ecfdfbde82dab54c9b04dc7fc83a9184aa2065d0"
+                "sha256:7c923ebdf007dbc8269d065014487c1692b7a092427cca1343353a842d37f0c1",
+                "sha256:b69c14dcfb46fc7965fb3d5f88f058dc12e2b8dc58a3e6aa2f408750fa2d83bf"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "unicodecsv": {
             "hashes": [

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -3,7 +3,8 @@ import logging
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import decorators, response, viewsets
 from rest_framework.parsers import JSONParser
-
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
 from . import ingest_settings, ingestors
 from .parsers import CsvParser
 from .serializers import UploadSerializer
@@ -23,6 +24,8 @@ class UploadViewSet(viewsets.ModelViewSet):
 @csrf_exempt
 @decorators.api_view(['POST'])
 @decorators.parser_classes((JSONParser, CsvParser))
+@decorators.authentication_classes([TokenAuthentication])
+@decorators.permission_classes([IsAuthenticated])
 def validate(request):
     """
     Apply all validators in settings to incoming data

--- a/data_ingest/fixtures/test_data.json
+++ b/data_ingest/fixtures/test_data.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "auth.user",
+    "pk": 1,
+    "fields": {
+      "password": "password",
+      "is_superuser": false,
+      "username": "diana",
+      "email": "diana@gsa.gov"
+    }
+  },
+  {
+    "model": "authtoken.token",
+    "pk": "this1s@t0k3n",
+    "fields": {
+      "user": 1,
+      "created": "2019-08-31T06:44:46.152Z"
+    }
+  }
+]

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -1,0 +1,27 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+class ApiValidateTests(APITestCase):
+
+    fixtures = ['test_data.json']
+
+    def test_api_validate_json_empty_no_token(self):
+        """
+        Ensure it is unauthorized when we post to the API for validation without a token.
+        """
+        url = reverse('validate')
+        data = []
+        response = self.client.post(url, data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_api_validate_json_empty_with_token(self):
+        """
+        Ensure we can post to the API for validation with a token.
+        """
+        url = reverse('validate')
+        data = []
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(url, data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)        

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+
 class ApiValidateTests(APITestCase):
 
     fixtures = ['test_data.json']
@@ -24,4 +25,4 @@ class ApiValidateTests(APITestCase):
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         response = self.client.post(url, data, content_type='application/json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -1,0 +1,49 @@
+import dj_database_url
+
+SECRET_KEY = 'fake-key-here'
+
+# Application definition
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'data_ingest',
+]
+
+ROOT_URLCONF = 'data_ingest.urls'
+
+# DATABASES = {
+#     'default': dj_database_url.config(conn_max_age=600),
+# }
+DATABASES={
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        }
+    }
+
+# Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated', )
+}
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -1,5 +1,3 @@
-import dj_database_url
-
 SECRET_KEY = 'fake-key-here'
 
 # Application definition
@@ -17,10 +15,7 @@ INSTALLED_APPS = [
 
 ROOT_URLCONF = 'data_ingest.urls'
 
-# DATABASES = {
-#     'default': dj_database_url.config(conn_max_age=600),
-# }
-DATABASES={
+DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
         }

--- a/data_ingest/urls.py
+++ b/data_ingest/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf.urls import include, url
 from rest_framework import routers
+from rest_framework.authtoken import views as authtoken_views
 
 from . import api_views, views
 
@@ -38,6 +39,7 @@ urlpatterns = [
         views.insert,
         name="insert",
     ),
+    url(r"^api/api-token-auth", authtoken_views.obtain_auth_token),
     url(r"^api/validate", api_views.validate, name="validate"),
     url(r"^api/", include(router.urls)),
     url(

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,19 +6,44 @@ Some operations are available via a RESTful API.
 List uploads
 ------------
 
-`GET` to /data_ingest/api/ for a list of all uploads.
+`GET` to `/data_ingest/api/` for a list of all uploads.
 
 Validate
 --------
 
-`POST` to /data_ingest/api/validate/ to apply your app's validator
+`POST` to `/data_ingest/api/validate/` to apply your app's validator
 to a payload.  This will not insert the rows, but will provide 
 error information.
+
+This endpoint requires a token authentication.  Admin should be able to log into the admin page at
+`/admin/` and under "Authentication And Authorization" -> "Users", click on "+ Add" to add a user.
+After a user has been added, they can obtain the token to authenticate.
+
+### Obtain Token
+`POST` to `/data_ingest/api/api-token-auth` to get the token for authentication.
+The data for the post is the `username` and `password` JSON object.
+```bash
+curl -X POST \
+-F username=<replace with what the admin gives you> \
+-F password=<replace with what the admin gives you> \
+http://localhost:8000/data_ingest/api/api-token-auth/
+```
+
+You will get a JSON response back with the token:
+```json
+{"token": "<Token to use for authentication on validate API>"}
+```
+
+Use this token in the header as shown below.
 
 ### Validate JSON data
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d @test_cases.json http://localhost:8000/data_ingest/api/validate/
+curl -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Token <Replace with your Token here>" \
+-d @test_cases.json \
+http://localhost:8000/data_ingest/api/validate/
 ```
 
 or, in Python,
@@ -29,14 +54,22 @@ import requests
 import json
 with open('test_cases.json') as infile:
     content = json.load(infile)
-resp = requests.post(url, json=content)
+resp = requests.post(url,
+                     json=content,
+                     headers={
+                        "Authorization": "Token <Replace with Token here in the form of environment variables, not raw text in the code>"
+                     })
 resp.json()
 ```
 
 ### Validate CSV data
 
 ```bash
-curl -X POST -H "Content-Type: text/csv" --data-binary @test_cases.csv http://localhost:8000/data_ingest/api/validate/
+curl -X POST \
+-H "Content-Type: text/csv" \
+-H "Authorization: Token <Replace with your Token here>" \
+--data-binary @test_cases.csv \
+http://localhost:8000/data_ingest/api/validate/
 ```
 
 or, in Python,
@@ -46,7 +79,12 @@ import requests
 url = 'http://localhost:8000/data_ingest/api/validate/'
 with open('test_cases.csv') as infile:
     content = infile.read()
-resp = requests.post(url, data=content, headers={"Content-Type": "text/csv"})
+resp = requests.post(url,
+                     data=content,
+                     headers={
+                        "Content-Type": "text/csv",
+                        "Authorization": "Token <Replace with Token here in the form of environment variables, not raw text in the code>"
+                     })
 resp.json()
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,8 +15,8 @@ Validate
 to a payload.  This will not insert the rows, but will provide 
 error information.
 
-This endpoint requires a token authentication.  Admin should be able to log into the admin page at
-`/admin/` and under "Authentication And Authorization" -> "Users", click on "+ Add" to add a user.
+This endpoint requires a token to authenticate.  Admin should be able to log into the admin page from a web browser
+at `/admin/` and under "Authentication And Authorization" -> "Users", click on "+ Add" to add a user.
 After a user has been added, they can obtain the token to authenticate.
 
 ### Obtain Token

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,6 @@ After a user has been added, they can obtain the token to authenticate.
 
 ### Obtain Token
 `POST` to `/data_ingest/api/api-token-auth` to get the token for authentication.
-The data for the post is the `username` and `password` JSON object.
 ```bash
 curl -X POST \
 -F username=<replace with what the admin gives you> \

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,9 +48,12 @@ http://localhost:8000/data_ingest/api/validate/
 or, in Python,
 
 ```python
-url = 'http://localhost:8000/data_ingest/api/validate/'
 import requests
 import json
+
+
+url = 'http://localhost:8000/data_ingest/api/validate/'
+
 with open('test_cases.json') as infile:
     content = json.load(infile)
 resp = requests.post(url,
@@ -75,7 +78,10 @@ or, in Python,
 
 ```python
 import requests
+
+
 url = 'http://localhost:8000/data_ingest/api/validate/'
+
 with open('test_cases.csv') as infile:
     content = infile.read()
 resp = requests.post(url,

--- a/examples/defaults/README.md
+++ b/examples/defaults/README.md
@@ -12,11 +12,18 @@ Create a PostgreSQL database named `default_ingestor`,
 run the initial migrations, and create a user account.
 
 This database is used for logging in and uploading files.  This is **not** used as the database for validation with SQL.  `SQLValidator` is currently using an in-memory SQLite database for validation.
-
+```bash
     createdb default_ingestor
     python manage.py migrate
     python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
         'chris', 'chris@gsa.gov', 'publicservice')"
+```
+
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+```bash
+    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
+        'username', 'admin@admin.com', 'password')"
+```
 
 Run the server.
 

--- a/examples/defaults/README.md
+++ b/examples/defaults/README.md
@@ -13,21 +13,22 @@ run the initial migrations, and create a user account.
 
 This database is used for logging in and uploading files.  This is **not** used as the database for validation with SQL.  `SQLValidator` is currently using an in-memory SQLite database for validation.
 ```bash
-    createdb default_ingestor
-    python manage.py migrate
-    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
-        'chris', 'chris@gsa.gov', 'publicservice')"
+createdb default_ingestor
+python manage.py migrate
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_user(
+    'chris', 'chris@gsa.gov', 'publicservice')"
 ```
 
-To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`.  You can replace the `username`, email address, and `password` with what you want accordingly:
 ```bash
-    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
-        'username', 'admin@admin.com', 'password')"
+python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
+    'username', 'admin@admin.com', 'password')"
 ```
 
 Run the server.
-
-    python manage.py runserver
+```bash
+python manage.py runserver
+```
 
 Visit http://localhost:8000/data_ingest/, login as `chris/publicservice`, and try uploading
 some CSVs (like the provided [example](staff.csv)).

--- a/examples/defaults/defaults/settings.py
+++ b/examples/defaults/defaults/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'data_ingest',
 ]
 
@@ -104,6 +105,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated', )
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/examples/p02_budgets/README.md
+++ b/examples/p02_budgets/README.md
@@ -78,6 +78,12 @@ python manage.py shell -c "from django.contrib.auth.models import User; User.obj
     'chris', 'chris@gsa.gov', 'publicservice')"
 ```
 
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+```bash
+    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
+        'username', 'admin@admin.com', 'password')"
+```
+
 Run the server.
 
 ```bash

--- a/examples/p02_budgets/README.md
+++ b/examples/p02_budgets/README.md
@@ -78,7 +78,7 @@ python manage.py shell -c "from django.contrib.auth.models import User; User.obj
     'chris', 'chris@gsa.gov', 'publicservice')"
 ```
 
-To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`.  You can replace the `username`, email address, and `password` with what you want accordingly:
 ```bash
     python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
         'username', 'admin@admin.com', 'password')"

--- a/examples/p02_budgets/p02_budgets/settings.py
+++ b/examples/p02_budgets/p02_budgets/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'budget_data_ingest',
     'rest_framework',
+    'rest_framework.authtoken',
     'data_ingest',
 ]
 
@@ -100,6 +101,15 @@ AUTH_PASSWORD_VALIDATORS = [
         'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+# Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated', )
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/examples/p03_budgets/README.md
+++ b/examples/p03_budgets/README.md
@@ -43,7 +43,7 @@ create a user account.
         'chris', 'chris@gsa.gov', 'publicservice')"
 ```
 
-To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`.  You can replace the `username`, email address, and `password` with what you want accordingly:
 ```bash
     python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
         'username', 'admin@admin.com', 'password')"

--- a/examples/p03_budgets/README.md
+++ b/examples/p03_budgets/README.md
@@ -43,6 +43,12 @@ create a user account.
         'chris', 'chris@gsa.gov', 'publicservice')"
 ```
 
+To create an administrator that can add users and control permissions, you can add the following superuser that can log into `/admin`, you can replace the `username` and `password` with what you want accordingly:
+```bash
+    python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser(
+        'username', 'admin@admin.com', 'password')"
+```
+
 Run the server.
 
 ```bash

--- a/examples/p03_budgets/p03_budgets/settings.py
+++ b/examples/p03_budgets/p03_budgets/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'budget_data_ingest',
     'rest_framework',
+    'rest_framework.authtoken',
     'data_ingest',
 ]
 
@@ -102,6 +103,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated', )
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/runtests.py
+++ b/runtests.py
@@ -1,26 +1,12 @@
+import os
 import sys
 
 import django
 from django.conf import settings
 from django.test.utils import get_runner
-import dj_database_url
 
-SETTINGS = {"DATABASES": {
-    'default': dj_database_url.config(conn_max_age=600),
-    },
-    "INSTALLED_APPS": [
-        'django.contrib.admin',
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.sessions',
-        'django.contrib.messages',
-        'django.contrib.staticfiles',
-        'data_ingest',
-        'data_ingest.tests'
-]
-}
 
-settings.configure(**SETTINGS)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'data_ingest.tests.test_settings'
 django.setup()
 
 TestRunner = get_runner(settings)


### PR DESCRIPTION
`data_ingest/api/validate` API endpoint was open to everyone for use, which seems very different from the approach of the UI that requires user to log in before uploading and validating.  Therefore, to make sure there's some basic guard around the `/validate` API endpoint, token authentication is implemented.

## Additions:
- Added token authentication for `/validate` endpoint
- Added basic API tests to test token authentication
- Added `/data_ingest/api/api-token-auth` endpoint for user to get token
- Added instructions on how admin can add new users, user can get token and use token for `/validate` endpoint

## Changes:
- Changed from test settings object to test settings file to include more settings to test API.
- Changed bandit settings to exclude test folders