### PR TITLE
Fix edge case where last extra column was not in error message

### DIFF
--- a/data_ingest/ingestors.py
+++ b/data_ingest/ingestors.py
@@ -420,7 +420,7 @@ class GoodtablesValidator(Validator):
                         {'errors': [{'code': 'extra-value',
                                     'column-number': 4,
                                     'message': 'Row 4 has an extra value in '
-                                                'column 4'}],
+                                                'column 4 (DBA)'}],
                         'row_number': 4,
                         'data': ['Catherine', '', '9', 'DBA']},
                         {'errors': [{'code': 'blank-row',
@@ -446,10 +446,11 @@ class GoodtablesValidator(Validator):
             message = err['message']
             # This is to include the header name with the column number and to define fields
             if err.get('column-number'):
-                if len(headers) > (err['column-number']):
-                    header = headers[err['column-number'] - 1]
+                column_number = err['column-number']
+                if len(headers) >= column_number:
+                    header = headers[column_number - 1]
                     fields = [header]
-                    column_num = 'column ' + str(err['column-number'])
+                    column_num = 'column ' + str(column_number)
                     message = err['message'].replace(column_num, column_num + ' (' + header + ')')
 
             if err.get('row-number'):

--- a/data_ingest/templates/data_ingest/review-errors.html
+++ b/data_ingest/templates/data_ingest/review-errors.html
@@ -32,7 +32,7 @@
           <h3>Whole-table errors</h3>
             <ul>
               {% for wte in whole_table_errors %}
-                <li>{{ wte }}</li>
+                <li>{{ wte.severity }} &mdash; {{ wte.message }}</li>
               {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
Fixes https://github.com/18F/ReVAL/issues/37 -- was an off by one error. Tried to add tests but it's pretty tough to mock up GoodtablesValidator; I can try again, though, if its important.

Used the following file to debug (taken from the associated issues) and used this with the `p02_budgets` example.

```csv
category,extra1,dollars_budgeted,extra2,dollars_spent
pencils,1,500,2,400
```