### PR TITLE
API refactor: delete

### DIFF
--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("ReVAL")
 
 class UploadViewSet(viewsets.ModelViewSet):
     """
+    Implements a REST API around `upload_model_class`.
     """
 
     queryset = ingest_settings.upload_model_class.objects.exclude(

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -10,13 +10,16 @@ from .permissions import IsAuthenticatedWithLogging
 from .serializers import UploadSerializer
 
 
-logger = logging.getLogger('ReVAL')
+logger = logging.getLogger("ReVAL")
 
 
 class UploadViewSet(viewsets.ModelViewSet):
     """
     """
-    queryset = ingest_settings.upload_model_class.objects.exclude(status='DELETED').order_by('-created_at')
+
+    queryset = ingest_settings.upload_model_class.objects.exclude(
+        status="DELETED"
+    ).order_by("-created_at")
     serializer_class = UploadSerializer
     parser_classes = [JSONParser, CsvParser]
 
@@ -25,12 +28,12 @@ class UploadViewSet(viewsets.ModelViewSet):
         Overridden method. Do not actually delete the instance; instead
         set the instance status to DELETED.
         """
-        instance.status = 'DELETED'
+        instance.status = "DELETED"
         instance.save()
 
 
 @csrf_exempt
-@decorators.api_view(['POST'])
+@decorators.api_view(["POST"])
 @decorators.parser_classes((JSONParser, CsvParser))
 @decorators.authentication_classes([TokenAuthenticationWithLogging])
 @decorators.permission_classes([IsAuthenticatedWithLogging])

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -16,9 +16,17 @@ logger = logging.getLogger('ReVAL')
 class UploadViewSet(viewsets.ModelViewSet):
     """
     """
-    queryset = ingest_settings.upload_model_class.objects.all().order_by(
-        'created_at')
+    queryset = ingest_settings.upload_model_class.objects.exclude(status='DELETED').order_by('-created_at')
     serializer_class = UploadSerializer
+    parser_classes = [JSONParser, CsvParser]
+
+    def perform_destroy(self, instance):
+        """
+        Overridden method. Do not actually delete the instance; instead
+        set the instance status to DELETED.
+        """
+        instance.status = 'DELETED'
+        instance.save()
 
 
 @csrf_exempt

--- a/data_ingest/models.py
+++ b/data_ingest/models.py
@@ -29,7 +29,6 @@ class Upload(models.Model):
         ('INSERTED', 'Inserted'),
         ('DELETED', 'Deleted'),
     )
-    _MAX_N_DESCRIPTIVE_FIELDS = 4
 
     submitter = models.ForeignKey(User, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -79,7 +78,7 @@ class Upload(models.Model):
             return ""
 
     def descriptive_fields(self):
-        return self.file_metadata or {'File Name': self.file.name}
+        return self.file_metadata or {'file_name': self.file.name}
 
 
 class DefaultUpload(Upload):

--- a/data_ingest/serializers.py
+++ b/data_ingest/serializers.py
@@ -5,4 +5,14 @@ from rest_framework import serializers
 class UploadSerializer(serializers.ModelSerializer):
     class Meta:
         model = ingest_settings.upload_model_class
-        fields = ('id', 'status', 'created_at', 'file_metadata')
+        fields = (
+            'id',
+            'created_at',
+            'updated_at',
+            'status',
+            'status_changed_by',
+            'status_changed_at',
+            'submitter',
+            'file_metadata',
+            'validation_results',
+        )

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -13,26 +13,26 @@ User = get_user_model()
 
 class ApiValidateTests(APITestCase):
 
-    fixtures = ['test_data.json']
+    fixtures = ["test_data.json"]
 
     def test_api_validate_json_empty_no_token(self):
         """
         Ensure it is unauthorized when we post to the API for validation without a token.
         """
-        url = reverse('validate')
+        url = reverse("validate")
         data = []
-        response = self.client.post(url, data, content_type='application/json')
+        response = self.client.post(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_api_validate_json_empty_with_token(self):
         """
         Ensure we can post to the API for validation with a token.
         """
-        url = reverse('validate')
+        url = reverse("validate")
         data = []
         token = "this1s@t0k3n"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
-        response = self.client.post(url, data, content_type='application/json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.post(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_delete_instance(self):
@@ -46,16 +46,16 @@ class ApiValidateTests(APITestCase):
         view = UploadViewSet()
         view.basename = router.get_default_basename(UploadViewSet)
         view.request = None
-        url = view.reverse_action('detail', args=[instance.pk])
+        url = view.reverse_action("detail", args=[instance.pk])
         data = []
         token = "this1s@t0k3n"
-        self.assertEqual(instance.status, 'LOADING')
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
-        response = self.client.delete(url, data, content_type='application/json')
+        self.assertEqual(instance.status, "LOADING")
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.delete(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(DefaultUpload.objects.count(), 1)
         instance = DefaultUpload.objects.first()
-        self.assertEqual(instance.status, 'DELETED')
+        self.assertEqual(instance.status, "DELETED")
 
     def test_api_delete_404(self):
         """
@@ -64,9 +64,9 @@ class ApiValidateTests(APITestCase):
         view = UploadViewSet()
         view.basename = router.get_default_basename(UploadViewSet)
         view.request = None
-        url = view.reverse_action('detail', args=['99'])
+        url = view.reverse_action("detail", args=["99"])
         data = []
         token = "this1s@t0k3n"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
-        response = self.client.delete(url, data, content_type='application/json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.delete(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -1,6 +1,14 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from ..models import DefaultUpload
+from ..api_views import UploadViewSet
+from ..urls import router
+
+
+User = get_user_model()
 
 
 class ApiValidateTests(APITestCase):
@@ -26,3 +34,39 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         response = self.client.post(url, data, content_type='application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_api_delete_instance(self):
+        """
+        Soft delete an instance.
+        """
+        submitter = User.objects.first()
+        DefaultUpload(submitter_id=submitter.pk).save()
+        self.assertEqual(DefaultUpload.objects.count(), 1)
+        instance = DefaultUpload.objects.first()
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action('detail', args=[instance.pk])
+        data = []
+        token = "this1s@t0k3n"
+        self.assertEqual(instance.status, 'LOADING')
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.delete(url, data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(DefaultUpload.objects.count(), 1)
+        instance = DefaultUpload.objects.first()
+        self.assertEqual(instance.status, 'DELETED')
+
+    def test_api_delete_404(self):
+        """
+        Make sure we cannot delete a non-existent instance.
+        """
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action('detail', args=['99'])
+        data = []
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.delete(url, data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,18 +1,17 @@
-API
-===
+# API
 
 Some operations are available via a RESTful API.
 
-List uploads
-------------
+## Upload endpoints
 
 `GET` to `/data_ingest/api/` for a list of all uploads.
+`DELETE` to `/data_ingest/api/:id` to delete an upload with the id `:id`.
+    - Will return 204 (no content) on success, 404 (not found) otherwise.
 
-Validate
---------
+## Validate endpoint
 
 `POST` to `/data_ingest/api/validate/` to apply your app's validator
-to a payload.  This will not insert the rows, but will provide 
+to a payload.  This will not insert the rows, but will provide
 error information.
 
 This endpoint requires a token to authenticate.  Admin should be able to log into the admin page from a web browser
@@ -20,7 +19,9 @@ at `/admin/` and under "Authentication And Authorization" -> "Users", click on "
 After a user has been added, they can obtain the token to authenticate.
 
 ### Obtain Token
+
 `POST` to `/data_ingest/api/api-token-auth` to get the token for authentication.
+
 ```bash
 curl -X POST \
 -F username=<replace with what the admin gives you> \

--- a/examples/defaults/defaults/settings.py
+++ b/examples/defaults/defaults/settings.py
@@ -109,6 +109,8 @@ AUTH_PASSWORD_VALIDATORS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
+        # allow the UI to use the API
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated', )

--- a/examples/p02_budgets/p02_budgets/settings.py
+++ b/examples/p02_budgets/p02_budgets/settings.py
@@ -106,6 +106,8 @@ AUTH_PASSWORD_VALIDATORS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
+        # allow the UI to use the API
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated', )

--- a/examples/p03_budgets/p03_budgets/settings.py
+++ b/examples/p03_budgets/p03_budgets/settings.py
@@ -107,6 +107,8 @@ AUTH_PASSWORD_VALIDATORS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
+        # allow the UI to use the API
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated', )


### PR DESCRIPTION
Splitting up the API refactor in a few pieces -- the idea is to better customize the django rest framework to provide what we want. This PR introduces DELETE (the simplest API call) and demonstrates how the UI can use the API internally. 

Note that we have to adjust `settings.REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASS` to support session auth (so that the UI can call the API); shouldn't change anything in regards to API usage itself. Tests included, but I haven't quite figured out what to do with documentation (may be a separate issue). 