### PR TITLE
API refactor: create

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: data_ingest
+          POSTGRES_HOST_AUTH_METHOD: trust
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: test_data_ingest
-          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PASSWORD: test_data_password
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           TZ: America/New_York
           PIPENV_VENV_IN_PROJECT: "TRUE"
-          DATABASE_URL: postgres://postgres@localhost/data_ingest
+          DATABASE_URL: postgresql://root@localhost/test_data_ingest?sslmode=disable
           CI_TESTING: "TRUE"
 
       - image: circleci/postgres:10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ jobs:
         environment:
           TZ: America/New_York
           PIPENV_VENV_IN_PROJECT: "TRUE"
-          DATABASE_URL: postgresql://root@localhost/test_data_ingest?sslmode=disable
+          DATABASE_URL: postgresql://postgres@localhost/test_data_ingest?sslmode=disable
           CI_TESTING: "TRUE"
 
       - image: circleci/postgres:10
         environment:
-          POSTGRES_USER: root
+          POSTGRES_USER: postgres
           POSTGRES_DB: test_data_ingest
           POSTGRES_PASSWORD: test_data_password
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
 
       - image: circleci/postgres:10
         environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: data_ingest
+          POSTGRES_USER: root
+          POSTGRES_DB: test_data_ingest
           POSTGRES_HOST_AUTH_METHOD: trust
 
     steps:

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -29,10 +29,9 @@ class UploadViewSet(viewsets.ModelViewSet):
         """
         Create a `upload_model_class`. Submitter id will be stored with
         this model. Validation errors, if any, will also be stored
-        with this model. If validation is successful, the object
-        status is set to STAGING, otherwise LOADING.
+        with this model. The object status is set to LOADING by default.
         """
-        data = request.data
+        data = request.data or {}
         data["submitter"] = request.user.id
 
         serializer = self.get_serializer(data=data)
@@ -51,7 +50,6 @@ class UploadViewSet(viewsets.ModelViewSet):
         try:
             result = ingestors.apply_validators_to(data, request.content_type)
             instance.validation_results = result
-            instance.status = 'STAGED' if result["valid"] else 'LOADING'
             instance.save()
         except AttributeError:
             message = {"error": "unexpected input"}

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -8,6 +8,7 @@ from .parsers import CsvParser
 from .permissions import IsAuthenticatedWithLogging
 from .serializers import UploadSerializer
 
+import json
 import logging
 
 
@@ -32,6 +33,7 @@ class UploadViewSet(viewsets.ModelViewSet):
         with this model. The object status is set to LOADING by default.
         """
         data = request.data or {}
+        data["raw"] = request.data
         data["submitter"] = request.user.id
 
         serializer = self.get_serializer(data=data)
@@ -45,7 +47,8 @@ class UploadViewSet(viewsets.ModelViewSet):
             message = {"error": str(error)}
             return response.Response(message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        # we don't want to validate the submitter datum
+        # we don't want to validate the `raw` or `submitter` fields
+        data.pop("raw")
         data.pop("submitter")
         try:
             result = ingestors.apply_validators_to(data, request.content_type)

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -1,13 +1,14 @@
-import logging
-
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework import decorators, response, viewsets
+from django.db import IntegrityError
+from rest_framework import decorators, response, viewsets, status
 from rest_framework.parsers import JSONParser
 from . import ingest_settings, ingestors
 from .authentication import TokenAuthenticationWithLogging
 from .parsers import CsvParser
 from .permissions import IsAuthenticatedWithLogging
 from .serializers import UploadSerializer
+
+import logging
 
 
 logger = logging.getLogger("ReVAL")
@@ -23,6 +24,40 @@ class UploadViewSet(viewsets.ModelViewSet):
     ).order_by("-created_at")
     serializer_class = UploadSerializer
     parser_classes = [JSONParser, CsvParser]
+
+    def create(self, request, *args, **kwargs):
+        """
+        Create a `upload_model_class`. Submitter id will be stored with
+        this model. Validation errors, if any, will also be stored
+        with this model. If validation is successful, the object
+        status is set to STAGING, otherwise LOADING.
+        """
+        data = request.data
+        data["submitter"] = request.user.id
+
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+
+        # save the serializer result separately
+        instance = None
+        try:
+            instance = serializer.save()
+        except IntegrityError as error:
+            message = {"error": str(error)}
+            return response.Response(message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # we don't want to validate the submitter datum
+        data.pop("submitter")
+        try:
+            result = ingestors.apply_validators_to(data, request.content_type)
+            instance.validation_results = result
+            instance.status = 'STAGED' if result["valid"] else 'LOADING'
+            instance.save()
+        except AttributeError:
+            message = {"error": "unexpected input"}
+            return response.Response(message, status=status.HTTP_400_BAD_REQUEST)
+
+        return response.Response(result)
 
     def perform_destroy(self, instance):
         """

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -31,6 +31,7 @@ class ApiValidateTests(APITestCase):
         Ensure we can post to the API for validation with a token.
         """
         url = reverse("validate")
+        data = {'source': b"[]"}
         data = []
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
@@ -68,6 +69,7 @@ class ApiValidateTests(APITestCase):
         view.request = None
         url = view.reverse_action("detail", args=["99"])
         data = []
+        url = reverse('validate')
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.delete(url, data, content_type="application/json")

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -115,9 +115,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        parse_error = "JSON parse error - Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
         self.assertEqual(
-            json.loads(response.content),
-            {
-                "detail": "JSON parse error - Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
-            },
+            json.loads(response.content), {"detail": parse_error},
         )

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -7,6 +7,8 @@ from ..models import DefaultUpload
 from ..api_views import UploadViewSet
 from ..urls import router
 
+import json
+
 
 User = get_user_model()
 
@@ -71,11 +73,34 @@ class ApiValidateTests(APITestCase):
         response = self.client.delete(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_api_create_example(self):
-        pass
-
     def test_api_create_empty(self):
-        pass
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action("list", args=[])
+        data = b"header1,header2,header3"
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.post(url, data, content_type="text/csv")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(json.loads(response.content)["valid"])
+
+    def test_api_create_csv_example(self):
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action("list", args=[])
+        data = b'"Name","Title","level"\n"Guido","BDFL",20\n\n"Catherine",,9,"DBA"\n,\n"Tony","Engineer",10\n'
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.post(url, data, content_type="text/csv")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = json.loads(response.content)
+        self.assertFalse(result["valid"])
+        self.assertEqual(len(result["tables"]), 1)
+        self.assertEqual(result["tables"][0]["invalid_row_count"], 3)
+        self.assertEqual(result["tables"][0]["valid_row_count"], 2)
+        self.assertEqual(result["tables"][0]["whole_table_errors"], [])
 
     def test_api_create_error_handling(self):
         """
@@ -85,8 +110,14 @@ class ApiValidateTests(APITestCase):
         view.basename = router.get_default_basename(UploadViewSet)
         view.request = None
         url = view.reverse_action("list", args=[])
-        data = []
+        data = "{foo}"
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                "detail": "JSON parse error - Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
+            },
+        )

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -70,3 +70,23 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.delete(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_api_create_example(self):
+        pass
+
+    def test_api_create_empty(self):
+        pass
+
+    def test_api_create_error_handling(self):
+        """
+        Make sure we handle malformed input when creating an instance.
+        """
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action("list", args=[])
+        data = []
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.post(url, data, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -102,6 +102,31 @@ class ApiValidateTests(APITestCase):
         self.assertEqual(result["tables"][0]["valid_row_count"], 2)
         self.assertEqual(result["tables"][0]["whole_table_errors"], [])
 
+    def test_api_create_json_example(self):
+        view = UploadViewSet()
+        view.basename = router.get_default_basename(UploadViewSet)
+        view.request = None
+        url = view.reverse_action("list", args=[])
+        data = json.dumps(
+            {
+                "source": [
+                    {"name": "Guido", "title": "BDFL", "level": 20},
+                    {"name": "Catherine", "level": 9},
+                    {"name": "Tony", "title": "Engineer", "level": 20},
+                ]
+            }
+        )
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.post(url, data, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = json.loads(response.content)
+        self.assertFalse(result["valid"])
+        self.assertEqual(len(result["tables"]), 1)
+        self.assertEqual(result["tables"][0]["invalid_row_count"], 1)
+        self.assertEqual(result["tables"][0]["valid_row_count"], 2)
+        self.assertEqual(result["tables"][0]["whole_table_errors"], [])
+
     def test_api_create_error_handling(self):
         """
         Make sure we handle malformed input when creating an instance.

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -31,8 +31,7 @@ class ApiValidateTests(APITestCase):
         Ensure we can post to the API for validation with a token.
         """
         url = reverse("validate")
-        data = {'source': b"[]"}
-        data = []
+        data = json.dumps({})
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="application/json")
@@ -69,7 +68,6 @@ class ApiValidateTests(APITestCase):
         view.request = None
         url = view.reverse_action("detail", args=["99"])
         data = []
-        url = reverse('validate')
         token = "this1s@t0k3n"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.delete(url, data, content_type="application/json")

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -37,6 +37,7 @@ DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'test_data_ingest',
+            'USERNAME': 'root',
         }
     }
 

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -37,7 +37,8 @@ DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'test_data_ingest',
-            'USERNAME': 'root',
+            'USER': 'root',
+            'PASSWORD': 'test_data_password',
         }
     }
 

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -36,7 +36,7 @@ TEMPLATES = [
 DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'test_ingestor',
+            'NAME': 'test_data_ingest',
         }
     }
 

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -35,7 +35,7 @@ TEMPLATES = [
 
 DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
+            'ENGINE': 'django.db.backends.postgresql',
         }
     }
 

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -37,8 +37,10 @@ DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'test_data_ingest',
-            'USER': 'root',
+            'USER': 'postgres',
             'PASSWORD': 'test_data_password',
+            'HOST': 'localhost',
+            'PORT': '5432',
         }
     }
 

--- a/data_ingest/tests/test_settings.py
+++ b/data_ingest/tests/test_settings.py
@@ -36,6 +36,7 @@ TEMPLATES = [
 DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'test_ingestor',
         }
     }
 

--- a/data_ingest/tests/test_utils.py
+++ b/data_ingest/tests/test_utils.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
 from unittest.mock import patch
+import json
 
 from data_ingest.utils import (
   get_schema_headers,
@@ -65,7 +66,7 @@ class TestJSONtoTable(SimpleTestCase):
         data = [{'col1': 1, "col2": 2, "col4": 4}, {'col1': 1, "col3": 3}]
         columns = ["col1", "col2", "col3"]
 
-        result = to_tabular(data)
+        result = to_tabular({"source": json.dumps(data).encode('UTF-8')})
         for col in columns:
             self.assertIn(col, result[0])
 

--- a/data_ingest/utils.py
+++ b/data_ingest/utils.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import io
 import logging
 from collections import OrderedDict
@@ -53,8 +54,15 @@ def to_tabular(incoming):
     are data rows containing data values in the order of headers defined
     in the first row.
     """
+    if incoming.get('source') is None:
+        return incoming
+
+    data = incoming.copy()
+
+    jsonbuffer = json.loads(data['source'].decode('UTF-8'))
+
     headers = set()
-    for row in incoming:
+    for row in jsonbuffer:
         for header in row.keys():
             headers.add(header)
 
@@ -63,7 +71,7 @@ def to_tabular(incoming):
     o_headers = get_ordered_headers(headers)
 
     output = [o_headers]
-    for row in incoming:
+    for row in jsonbuffer:
         row_data = []
         for header in o_headers:
             logger.debug(f"Fetching: {header}")

--- a/data_ingest/utils.py
+++ b/data_ingest/utils.py
@@ -59,7 +59,13 @@ def to_tabular(incoming):
 
     data = incoming.copy()
 
-    jsonbuffer = json.loads(data['source'].decode('UTF-8'))
+    # if we are going through the API, the JSONDecoder already
+    # converts the source JSON to a python dictionary for us.
+    jsonbuffer = None
+    try:
+        jsonbuffer = json.loads(data["source"].decode())
+    except (TypeError, KeyError, AttributeError):
+        jsonbuffer = data['source']
 
     headers = set()
     for row in jsonbuffer:

--- a/data_ingest/views.py
+++ b/data_ingest/views.py
@@ -110,7 +110,6 @@ def upload(request, replace_upload_id=None, **kwargs):
                 file_metadata=metadata,
                 raw=form.cleaned_data["file"].read(),
             )
-            # TODO what is file_metadata and raw?
             instance.save()
             if replace_upload_id is None:
                 replace_upload = instance.duplicate_of()

--- a/data_ingest/views.py
+++ b/data_ingest/views.py
@@ -110,6 +110,7 @@ def upload(request, replace_upload_id=None, **kwargs):
                 file_metadata=metadata,
                 raw=form.cleaned_data["file"].read(),
             )
+            # TODO what is file_metadata and raw?
             instance.save()
             if replace_upload_id is None:
                 replace_upload = instance.duplicate_of()


### PR DESCRIPTION
Builds on #89 

Somewhat more complicated due to supporting JSON and CSV through the API (this did not work before). No UI code is touched (it's rather difficult to make the UI call the API due to the presence of the `upload_form_class`). Future API endpoints like `update` and `partial_update` (plus the custom endpoints such as `insert` and `stage`) will be called from the UI, though. Adds a bunch of new tests for the API create endpoint. 