### PR TITLE
API refactor: replace and upload

### DIFF
--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -126,9 +126,6 @@ class UploadViewSet(viewsets.ModelViewSet):
         instance = None
         try:
             instance = serializer.save()
-            if existing_instance and not replace:
-                instance.replaces = existing_instance
-                instance.save()
         except IntegrityError as error:
             message = {"error": str(error)}
             return response.Response(
@@ -141,6 +138,8 @@ class UploadViewSet(viewsets.ModelViewSet):
             result = ingestors.apply_validators_to(request.data, request.content_type)
             instance.validation_results = result
             instance.status = "LOADING"
+            if existing_instance and not replace:
+                instance.replaces = existing_instance
             instance.save()
         except AttributeError:
             message = {"error": "unexpected input"}

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -58,6 +58,27 @@ class UploadViewSet(viewsets.ModelViewSet):
         upload.save()
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
+    # TODO equivalent of replace
+    # TODO must set upload.replaces
+    # TODO must validate
+    def update(self, request, pk=None):
+        """
+        Replace a pre-existing `upload_model_class`. Validation errors, if
+        any, will be stored with this model and validation results
+        will be returned.
+        """
+        upload = self.get_object()
+        # TODO create
+        pass
+
+    # TODO must validate
+    def partial_update(self, request, pk=None):
+        """
+        Update the `upload_model_class` and re-validate.
+        """
+        upload = self.get_object()
+        pass
+
     def create(self, request, *args, **kwargs):
         """
         Create a `upload_model_class`. Submitter id will be stored with

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -74,7 +74,9 @@ class UploadViewSet(viewsets.ModelViewSet):
         model and validation results will be returned.
         """
         upload = self.get_object()
-        return self._process_upload_model_class(request, existing_instance=upload, replace=True)
+        return self._process_upload_model_class(
+            request, existing_instance=upload, replace=True
+        )
 
     def create(self, request, *args, **kwargs):
         """
@@ -92,7 +94,9 @@ class UploadViewSet(viewsets.ModelViewSet):
         instance.status = "DELETED"
         instance.save()
 
-    def _process_upload_model_class(self, request, existing_instance=None, replace=False):
+    def _process_upload_model_class(
+        self, request, existing_instance=None, replace=False
+    ):
         """
         Process an `upload_model_class` instance by validating the request
         data. If `existing_instance` is given, it may be replaced
@@ -108,9 +112,14 @@ class UploadViewSet(viewsets.ModelViewSet):
             if k not in ["source", "format", "headers"]
         }
         data["submitter"] = request.user.id
-        data["id"] = existing_instance.id if existing_instance and replace else None
+        if existing_instance and replace:
+            data["id"] = existing_instance.id
 
-        serializer = self.get_serializer(data=data)
+        serializer = (
+            self.get_serializer(existing_instance, data=data)
+            if existing_instance and replace
+            else self.get_serializer(data=data)
+        )
         serializer.is_valid(raise_exception=True)
 
         # save the serializer result separately

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -294,7 +294,15 @@ class ApiValidateTests(APITestCase):
         self.assertEqual(result["tables"][0]["whole_table_errors"], [])
         self.assertEqual(DefaultUpload.objects.count(), 1)
         instance = DefaultUpload.objects.get(pk=instance.pk)
-        self.assertEqual(instance.validation_results, None)
+        # make sure the saved validation results are the same as what
+        # is returned via the API
+        result = instance.validation_results
+        self.assertFalse(result["valid"])
+        self.assertEqual(len(result["tables"]), 1)
+        self.assertEqual(result["tables"][0]["invalid_row_count"], 1)
+        self.assertEqual(result["tables"][0]["valid_row_count"], 2)
+        self.assertEqual(result["tables"][0]["whole_table_errors"], [])
+        self.assertEqual(DefaultUpload.objects.count(), 1)
 
     def test_api_replace_404(self):
         """

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -19,7 +19,7 @@ class ApiValidateTests(APITestCase):
 
     def create_instance(self, count=1):
         """
-        Create an `DefaultUpload` instance for testing.
+        Helper function: Create an `DefaultUpload` instance.
         """
         submitter = User.objects.first()
         DefaultUpload(submitter_id=submitter.pk).save()
@@ -27,6 +27,9 @@ class ApiValidateTests(APITestCase):
         return DefaultUpload.objects.first()
 
     def get_url(self, what, args=None):
+        """
+        Helper function: get an url from the upload API.
+        """
         view = UploadViewSet()
         view.basename = router.get_default_basename(UploadViewSet)
         view.request = None
@@ -80,6 +83,9 @@ class ApiValidateTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_api_create_empty(self):
+        """
+        Make sure we can create an empty (trivial) validated object.
+        """
         url = self.get_url("list")
         data = b"header1,header2,header3"
         token = "this1s@t0k3n"
@@ -89,6 +95,9 @@ class ApiValidateTests(APITestCase):
         self.assertTrue(json.loads(response.content)["valid"])
 
     def test_api_create_csv_example(self):
+        """
+        Make sure we can upload CSV data and get validation errors.
+        """
         url = self.get_url("list")
         data = b'"Name","Title","level"\n"Guido","BDFL",20\n\n"Catherine",,9,"DBA"\n,\n"Tony","Engineer",10\n'
         token = "this1s@t0k3n"
@@ -103,6 +112,9 @@ class ApiValidateTests(APITestCase):
         self.assertEqual(result["tables"][0]["whole_table_errors"], [])
 
     def test_api_create_json_example(self):
+        """
+        Make sure we can upload JSON and get validation errors.
+        """
         url = self.get_url("list")
         data = json.dumps(
             {
@@ -225,3 +237,31 @@ class ApiValidateTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         instance = DefaultUpload.objects.get(pk=instance.pk)
         self.assertEqual(instance.status, "INSERTED")
+
+    def test_api_in_place_replace_404(self):
+        """
+        Make sure we cannot patch a non-existent instance.
+        """
+        url = self.get_url("detail", args=["99"])
+        data = []
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.patch(url, data, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_api_in_place_replace(self):
+        pass
+
+    def test_api_replace_404(self):
+        """
+        Make sure we cannot replace a non-existent instance.
+        """
+        url = self.get_url("detail", args=["99"])
+        data = []
+        token = "this1s@t0k3n"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
+        response = self.client.put(url, data, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_api_replace(self):
+        pass


### PR DESCRIPTION
Adds PATCH/PUT methods. Does not touch views -- the current way of replacing (via `old_upload_id` and `new_upload_id`) works just fine. 