### PR TITLE
API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For the API, it can perform data validation, and view uploads that were done via
 
 If you would like to use ReVAL in your Django project, install using `pipenv` in your project...
 
-- Replace `<version>` with the latest tag i.e. `v0.2` or
+- Replace `<version>` with the latest tag i.e. `v0.7.0` or
 - Replace with `master` if you would like to work with the latest development version
 
 ```bash

--- a/data_ingest/api_views.py
+++ b/data_ingest/api_views.py
@@ -145,7 +145,8 @@ class UploadViewSet(viewsets.ModelViewSet):
             message = {"error": "unexpected input"}
             return response.Response(message, status=status.HTTP_400_BAD_REQUEST)
 
-        return response.Response(result)
+        json_data = UploadSerializer(instance).data
+        return response.Response(json_data)
 
 
 @csrf_exempt

--- a/data_ingest/templates/data_ingest/confirm-upload.html
+++ b/data_ingest/templates/data_ingest/confirm-upload.html
@@ -5,7 +5,7 @@
 <h1>Confirm upload</h1>
 <div>
   <p>Please verify the information below before finalizing your upload.</p>
-  <a class="usa-button" href="{% url 'complete-upload' upload_id %}">Complete upload</a>
+  <a class="usa-button" href="{% url 'stage-upload' upload_id %}">Stage upload</a>
 </div>
   <div class="usa-width-one-half">
     <h2>Verify file attributes</h2>

--- a/data_ingest/tests/test_api_view.py
+++ b/data_ingest/tests/test_api_view.py
@@ -92,7 +92,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="text/csv")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(json.loads(response.content)["valid"])
+        self.assertTrue(json.loads(response.content)["validation_results"]["valid"])
 
     def test_api_create_csv_example(self):
         """
@@ -104,7 +104,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="text/csv")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result = json.loads(response.content)
+        result = json.loads(response.content)["validation_results"]
         self.assertFalse(result["valid"])
         self.assertEqual(len(result["tables"]), 1)
         self.assertEqual(result["tables"][0]["invalid_row_count"], 3)
@@ -129,7 +129,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.post(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result = json.loads(response.content)
+        result = json.loads(response.content)["validation_results"]
         self.assertFalse(result["valid"])
         self.assertEqual(len(result["tables"]), 1)
         self.assertEqual(result["tables"][0]["invalid_row_count"], 1)
@@ -286,7 +286,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.patch(url, data, content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result = json.loads(response.content)
+        result = json.loads(response.content)["validation_results"]
         self.assertFalse(result["valid"])
         self.assertEqual(len(result["tables"]), 1)
         self.assertEqual(result["tables"][0]["invalid_row_count"], 1)
@@ -328,7 +328,7 @@ class ApiValidateTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.put(url, data, content_type="text/csv")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result = json.loads(response.content)
+        result = json.loads(response.content)["validation_results"]
         self.assertFalse(result["valid"])
         self.assertEqual(len(result["tables"]), 1)
         self.assertEqual(result["tables"][0]["invalid_row_count"], 3)

--- a/data_ingest/urls.py
+++ b/data_ingest/urls.py
@@ -26,9 +26,9 @@ urlpatterns = [
     url(r"^delete-upload/(?P<upload_id>\d+)",
         views.delete_upload,
         name="delete-upload"),
-    url(r"^complete-upload/(?P<upload_id>\d+)",
-        views.complete_upload,
-        name="complete-upload"),
+    url(r"^stage-upload/(?P<upload_id>\d+)",
+        views.stage_upload,
+        name="stage-upload"),
     url(
         r"^upload-detail/(?P<pk>\d+)",
         views.UploadDetail.as_view(),

--- a/data_ingest/views.py
+++ b/data_ingest/views.py
@@ -150,7 +150,7 @@ def confirm_upload(request, upload_id):
     return render(request, "data_ingest/confirm-upload.html", data)
 
 
-def complete_upload(request, upload_id):
+def stage_upload(request, upload_id):
     Api.call(request, "stage", pk=upload_id)
     return redirect("index")
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,30 +78,34 @@ This token may be retrieved by the user ([see the `Obtaining a Token` example be
 
 # Examples
 
+These examples assume the default example project (included in this repository) is running on port 8000, and as such the default url is `http://localhost:8000/data_ingest`. Please adjust the url accordingly for your project.
+
 ## Obtaining a Token
 
-`POST` to `/data_ingest/api/api-token-auth` to get the token for authentication.
+You may `POST` to `/api/api-token-auth` to get your user token for authentication.
+
+<details><summary>Example</summary>
 
 ```bash
-curl -X POST \
-  -F username=<your username> \
-  -F password=<your password> \
+curl -s -X POST \
+  -F username=your_username_here \
+  -F password=your_password_here \
   http://localhost:8000/data_ingest/api/api-token-auth/
 ```
 
-You will get a JSON response back with the token:
-
 ```json
-{"token": "<Token to use for authentication>"}
+{"token":"faketoken"}
 ```
 
-Use this token in the header for the rest of the examples below.
+We will use this fake token in the header for the rest of the examples below. If following along, be sure to replace this fake token with your own token!
+
+</details>
 
 ## Example data
 
-We provide some sample runs which use the `curl` command line tool. These runs use the following data examples:
+We provide some sample runs which use the `curl` command line tool. Some of these runs use the following (deliberately incorrect) data examples:
 
-<details><summary>CSV example: test_cases.csv</summary>
+<details><summary>Example (CSV): test_cases.csv</summary>
 
 ```csv
 "Name","Title","level"
@@ -114,34 +118,223 @@ We provide some sample runs which use the `curl` command line tool. These runs u
 
 </details>
 
-<details><summary>JSON example: test_cases.json</summary>
+<details><summary>Example (JSON): test_cases.json</summary>
 
 ```json
-[
+{
+  "source": [
     {
       "Name": "Guido",
       "Title": "BDFL",
       "level": "20"
+    },
+    {},
+    {
+      "Name": "Catherine",
+      "extra": "information",
+      "level": 9,
+      "Title": "DBA"
     },
     {
       "Name": "Tony",
       "Title": "Engineer",
       "level": "10"
     }
-]
+  ]
+}
 ```
 
 </details>
 
-
 ## List uploads
+
+<details><summary>Example</summary>
+
+```bash
+curl -s -X GET \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/
+```
+
+```json
+TODO
+```
+
+</details>
+
 ## Get upload
+
+<details><summary>Example</summary>
+
+```bash
+curl -s -X GET \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/1
+```
+
+```json
+TODO
+```
+
+</details>
+
 ## Create upload
+
+<details><summary>Example (JSON)</summary>
+
+```bash
+curl -s -X POST \
+  -d @test_cases.json \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/
+```
+
+```json
+TODO
+```
+
+</details>
+
+<details><summary>Example (CSV)</summary>
+
+```bash
+curl -s -X POST \
+  -d @test_cases.json \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/
+```
+
+```json
+TODO
+```
+
+</details>
+
 ## Replace upload
+
+<details><summary>Example (JSON)</summary>
+
+```bash
+curl -s -X PUT \
+  -d @test_cases.json \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/1/
+```
+
+```json
+TODO
+```
+
+</details>
+
+<details><summary>Example (CSV)</summary>
+
+```bash
+curl -s -X PUT \
+  --data-binary @test_cases.csv \
+  -H "Content-Type: text/csv" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/1/
+```
+
+```json
+TODO
+```
+
+</details>
+
 ## Replace upload in-place
+
+<details><summary>Example (JSON)</summary>
+
+```bash
+curl -s -X PATCH \
+  -d @test_cases.json \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/1/
+```
+
+```json
+TODO
+```
+
+</details>
+
+<details><summary>Example (CSV)</summary>
+
+```bash
+curl -s -X PATCH \
+  --data-binary @test_cases.csv \
+  -H "Content-Type: text/csv" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/1/
+```
+
+```json
+TODO
+```
+
+</details>
+
 ## Delete upload
+
+<details><summary>Example</summary>
+
+```bash
+curl -s -X DELETE \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/4
+```
+
+```json
+```
+
+Note: on success, a 204 (no content) response code is returned.
+
+</details>
+
 ## Stage upload
+
+<details><summary>Example</summary>
+
+```bash
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/5/stage/
+```
+
+```json
+```
+
+Note: on success, a 204 (no content) response code is returned.
+
+</details>
+
 ## Insert upload
+
+<details><summary>Example</summary>
+
+```bash
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token faketoken" \
+  http://localhost:8000/data_ingest/api/6/insert/
+```
+
+```json
+```
+
+Note: on success, a 204 (no content) response code is returned.
+
+</details>
 
 ## Validating
 
@@ -150,9 +343,96 @@ We provide some sample runs which use the `curl` command line tool. These runs u
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -H "Authorization: Token <Replace with your Token here>" \
+  -H "Authorization: Token faketoken" \
   -d @test_cases.json \
   http://localhost:8000/data_ingest/api/validate/
+```
+
+```json
+{
+  "tables": [
+    {
+      "headers": [
+        "extra",
+        "level",
+        "Title",
+        "Name"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 2 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "20",
+            "Title": "BDFL",
+            "Name": "Guido"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": null,
+            "Title": null,
+            "Name": null
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [],
+          "data": {
+            "extra": "information",
+            "level": 9,
+            "Title": "DBA",
+            "Name": "Catherine"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 5 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "10",
+            "Title": "Engineer",
+            "Name": "Tony"
+          }
+        }
+      ],
+      "valid_row_count": 1,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
+
 ```
 
 </details>
@@ -162,9 +442,95 @@ curl -X POST \
 ```bash
 curl -X POST \
   -H "Content-Type: text/csv" \
-  -H "Authorization: Token <token>" \
+  -H "Authorization: Token faketoken" \
   --data-binary @test_cases.csv \
   http://localhost:8000/data_ingest/api/validate/
+```
+
+```json
+{
+  "tables": [
+    {
+      "headers": [
+        "Name",
+        "Title",
+        "level"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [],
+          "data": {
+            "Name": "Guido",
+            "Title": "BDFL",
+            "level": "20"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "extra-value",
+              "message": "Row 4 has an extra value in column 4",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "Catherine",
+            "Title": "",
+            "level": "9"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 5 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 6,
+          "errors": [],
+          "data": {
+            "Name": "Tony",
+            "Title": "Engineer",
+            "level": "10"
+          }
+        }
+      ],
+      "valid_row_count": 2,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,7 +87,53 @@ You will get a JSON response back with the token:
 
 Use this token in the header for the rest of the examples below.
 
-## Validating JSON data
+## Example data
+
+We provide some sample runs which use the `curl` command line tool. These runs use the following data examples:
+
+<details><summary>CSV example: test_cases.csv</summary>
+
+```csv
+"Name","Title","level"
+"Guido","BDFL",20
+
+"Catherine",,9,"DBA"
+,
+"Tony","Engineer",10
+```
+
+</details>
+
+<details><summary>JSON example: test_cases.json</summary>
+
+```json
+[
+    {
+      "Name": "Guido",
+      "Title": "BDFL",
+      "level": "20"
+    },
+    {
+      "Name": "Tony",
+      "Title": "Engineer",
+      "level": "10"
+    }
+]
+```
+
+</details>
+
+
+## List uploads
+## Get upload
+## Create upload
+## Replace upload
+## Replace upload in-place
+## Delete upload
+## Stage upload
+## Insert upload
+
+## Validating
 
 <details><summary>Curl</summary>
 
@@ -97,27 +143,6 @@ curl -X POST \
   -H "Authorization: Token <Replace with your Token here>" \
   -d @test_cases.json \
   http://localhost:8000/data_ingest/api/validate/
-```
-
-</details>
-
-<details><summary>Python</summary>
-
-```python
-import requests
-import json
-
-
-url = 'http://localhost:8000/data_ingest/api/validate/'
-
-with open('test_cases.json') as infile:
-    content = json.load(infile)
-resp = requests.post(url,
-                     json=content,
-                     headers={
-                        "Authorization": "Token <token>"
-                     })
-resp.json()
 ```
 
 </details>
@@ -136,20 +161,24 @@ curl -X POST \
 
 </details>
 
-<details><summary>Python</summary>
+## Python
+
+We provide a sample python example, which uses the [`requests` library](https://requests.readthedocs.io/en/master/ "requests library").
+
+<details><summary>API</summary>
 
 ```python
 import requests
 
 
-url = 'http://localhost:8000/data_ingest/api/validate/'
+url = "http://localhost:8000/data_ingest/api/"
 
-with open('test_cases.csv') as infile:
+with open("test_cases.json") as infile:  # or "test_cases.csv"
     content = infile.read()
 resp = requests.post(url,
                      data=content,
                      headers={
-                        "Content-Type": "text/csv",
+                        "Content-Type": "application/json",  # or "text/csv"
                         "Authorization": "Token <token>"
                      })
 resp.json()
@@ -157,14 +186,27 @@ resp.json()
 
 </details>
 
-## List uploads
-## Get upload
-## Create upload
-## Replace upload
-## Replace upload in-place
-## Delete upload
-## Stage upload
-## Insert upload
+<details><summary>Validate</summary>
+
+```python
+import requests
+import json
+
+
+url = "http://localhost:8000/data_ingest/api/validate/"
+
+with open("test_cases.json") as infile:  # or "test_cases.csv"
+    content = json.load(infile)
+resp = requests.post(url,
+                     json=content,
+                     headers={
+                        "Content-Type": "application/json",  # or "text/csv"
+                        "Authorization": "Token <token>"
+                     })
+resp.json()
+```
+
+</details>
 
 # Validation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,22 +1,71 @@
 # API
 
-Some operations are available via a RESTful API.
+ReVal provides a RESTful API to manage `DATA_INGEST['MODEL']` instances. The default API routing prefix is `/api/`, as defined in [urls.py](../data_ingest/urls.py "urls.py for data_ingest"). API requests may have a content type of either `text/csv` or `application/json`, but all API responses will be in JSON.
 
-## Upload endpoints
+TODO: document model statuses here
 
-`GET` to `/data_ingest/api/` for a list of all uploads.
-`DELETE` to `/data_ingest/api/:id` to delete an upload with the id `:id`.
-    - Will return 204 (no content) on success, 404 (not found) otherwise.
+# Endpoints
+
+Supported endpoints are:
+
+- `GET` `/api/`: obtain a list of all uploads.
+  - Returns 200.
+
+- `GET` `/api/:id`: obtain upload data.
+  - Returns 200 with upload data.
+  - If `:id:` does not exist, returns 404 (not found).
+
+- `POST` `/api`:
+  - Returns 200 with validation information.
+
+- `PUT` `/api/:id`: replace an upload and validate upload
+  - Returns 200 with validation information; the previous upload is saved as `replaces`. Note that a new id is generated. TODO
+  - If `:id:` does not exist, returns 404 (not found).
+
+- `PATCH` `/api/:id`: replace an upload in-place and validate upload
+  - Returns 200 with validation information; the previous upload is not saved.
+  - If `:id:` does not exist, returns 404 (not found).
+
+- `DELETE` `/api/:id`: delete an upload with the id `:id`.
+  - Returns 204 (no content) on success.
+  - If `:id:` does not exist, returns 404 (not found).
+
+The API also provides some custom endpoints for managing uploads:
+
+- `POST` `/api/:id/stage`:
+  - Stages the upload information (sets status to `STAGED`)
+  - Returns 204 (no content) on success.
+
+- `POST` `/api/:id/insert`:
+  - Inserts the upload information (sets status to `INSERTED`)
+  - If upload is not `STAGED`, returns a 400 (bad request).
+  - Returns 204 (no content) on success.
+
+The API will also return a 400 (bad request) for any requests that the API can not parse.
+
+The API will also return a 500 (internal server error), along with an error message, if the database cannot save the upload for any reason.
 
 ## Validate endpoint
 
-`POST` to `/data_ingest/api/validate/` to apply your app's validator
-to a payload.  This will not insert the rows, but will provide
-error information.
+The API also provides a stand-alone validation endpoint:
 
-This endpoint requires a token to authenticate.  Admin should be able to log into the admin page from a web browser
-at `/admin/` and under "Authentication And Authorization" -> "Users", click on "+ Add" to add a user.
-After a user has been added, they can obtain the token to authenticate.
+- `POST` `/api/validate`: Apply configured validator(s) to request data.
+  - Does not insert data in the database.
+  - Returns 200 with validation information.
+
+# Authentication
+
+API endpoints require a [django-rest framework token to authenticate](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication "token to authenticate from the django-rest framework").
+
+Each user will require a token to authenticate against the API.
+
+One way to do this is to log in as a super user and use the Django `/admin` interface:
+
+1. Add an user (if not already done) at `/admin/auth/user/add/`.
+2. Create a new token at `/admin/authtoken/token/add/`.
+
+# Examples
+
 
 ### Obtain Token
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,17 @@
 
 ReVal provides a RESTful API to manage `DATA_INGEST['MODEL']` instances. The default API routing prefix is `/api/`, as defined in [urls.py](../data_ingest/urls.py "urls.py for data_ingest"). API requests may have a content type of either `text/csv` or `application/json`, but all API responses will be in JSON.
 
-TODO: document model statuses here
+The default upload model has the following statuses:
+
+- `LOADING`: initial insert of upload data in the database.
+
+- `PENDING`: not used at present.
+
+- `STAGED`: stage upload data for final review.
+
+- `INSERTED`: finalize upload data and associated validation results.
+
+- `DELETED`: indicates a deleted upload: a "soft" delete.
 
 # Endpoints
 
@@ -43,7 +53,7 @@ The API also provides some custom endpoints for managing uploads:
 
 The API will also return a 400 (bad request) for any requests that the API can not parse.
 
-The API will also return a 500 (internal server error), along with an error message, if the database cannot save the upload for any reason.
+The API will also return a 500 (internal server error), along with an error message, if the database cannot save the upload data for any reason.
 
 ## Validate endpoint
 
@@ -135,7 +145,7 @@ We provide some sample runs which use the `curl` command line tool. These runs u
 
 ## Validating
 
-<details><summary>Curl</summary>
+<details><summary>Example (JSON)</summary>
 
 ```bash
 curl -X POST \
@@ -147,9 +157,7 @@ curl -X POST \
 
 </details>
 
-## Validating CSV data
-
-<details><summary>Curl</summary>
+<details><summary>Example (CSV)</summary>
 
 ```bash
 curl -X POST \
@@ -166,6 +174,8 @@ curl -X POST \
 We provide a sample python example, which uses the [`requests` library](https://requests.readthedocs.io/en/master/ "requests library").
 
 <details><summary>API</summary>
+
+TODO run examples
 
 ```python
 import requests

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ Supported endpoints are:
   - Returns 200 with validation information.
 
 - `PUT` `/api/:id`: replace an upload and validate upload
-  - Returns 200 with validation information; the previous upload is saved as `replaces`. Note that a new id is generated. TODO
+  - Returns 200 with validation information; the previous upload is saved as `replaces`. Note that a new id is generated.
   - If `:id:` does not exist, returns 404 (not found).
 
 - `PATCH` `/api/:id`: replace an upload in-place and validate upload
@@ -380,87 +380,97 @@ curl -s -X POST \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "extra",
-        "level",
-        "Title",
-        "Name"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 2 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+  "id": 1,
+  "created_at": "2020-03-19T22:47:40.509878Z",
+  "updated_at": "2020-03-19T22:47:40.621499Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": null,
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "extra",
+          "level",
+          "Title",
+          "Name"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 2 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "20",
+              "Title": "BDFL",
+              "Name": "Guido"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "20",
-            "Title": "BDFL",
-            "Name": "Guido"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": null,
+              "Title": null,
+              "Name": null
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": null,
-            "Title": null,
-            "Name": null
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [],
-          "data": {
-            "extra": "information",
-            "level": 9,
-            "Title": "DBA",
-            "Name": "Catherine"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 5 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+          },
+          {
+            "row_number": 4,
+            "errors": [],
+            "data": {
+              "extra": "information",
+              "level": 9,
+              "Title": "DBA",
+              "Name": "Catherine"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "10",
-            "Title": "Engineer",
-            "Name": "Tony"
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 5 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "10",
+              "Title": "Engineer",
+              "Name": "Tony"
+            }
           }
-        }
-      ],
-      "valid_row_count": 1,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 1,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 
@@ -478,87 +488,97 @@ curl -s -X POST \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "Name",
-        "Title",
-        "level"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [],
-          "data": {
-            "Name": "Guido",
-            "Title": "BDFL",
-            "level": "20"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+  "id": 2,
+  "created_at": "2020-03-19T22:48:15.770146Z",
+  "updated_at": "2020-03-19T22:48:15.881419Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "Name",
+          "Title",
+          "level"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [],
+            "data": {
+              "Name": "Guido",
+              "Title": "BDFL",
+              "level": "20"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "extra-value",
-              "message": "Row 4 has an extra value in column 4",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
             }
-          ],
-          "data": {
-            "Name": "Catherine",
-            "Title": "",
-            "level": "9"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 5 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 4,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "extra-value",
+                "message": "Row 4 has an extra value in column 4",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "Catherine",
+              "Title": "",
+              "level": "9"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 5 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
+            }
+          },
+          {
+            "row_number": 6,
+            "errors": [],
+            "data": {
+              "Name": "Tony",
+              "Title": "Engineer",
+              "level": "10"
+            }
           }
-        },
-        {
-          "row_number": 6,
-          "errors": [],
-          "data": {
-            "Name": "Tony",
-            "Title": "Engineer",
-            "level": "10"
-          }
-        }
-      ],
-      "valid_row_count": 2,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 2,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 
@@ -578,87 +598,97 @@ curl -s -X PUT \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "extra",
-        "level",
-        "Title",
-        "Name"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 2 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+  "id": 3,
+  "created_at": "2020-03-19T22:48:37.980498Z",
+  "updated_at": "2020-03-19T22:48:38.090478Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "extra",
+          "level",
+          "Title",
+          "Name"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 2 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "20",
+              "Title": "BDFL",
+              "Name": "Guido"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "20",
-            "Title": "BDFL",
-            "Name": "Guido"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": null,
+              "Title": null,
+              "Name": null
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": null,
-            "Title": null,
-            "Name": null
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [],
-          "data": {
-            "extra": "information",
-            "level": 9,
-            "Title": "DBA",
-            "Name": "Catherine"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 5 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+          },
+          {
+            "row_number": 4,
+            "errors": [],
+            "data": {
+              "extra": "information",
+              "level": 9,
+              "Title": "DBA",
+              "Name": "Catherine"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "10",
-            "Title": "Engineer",
-            "Name": "Tony"
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 5 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "10",
+              "Title": "Engineer",
+              "Name": "Tony"
+            }
           }
-        }
-      ],
-      "valid_row_count": 1,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 1,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 
@@ -676,87 +706,97 @@ curl -s -X PUT \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "Name",
-        "Title",
-        "level"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [],
-          "data": {
-            "Name": "Guido",
-            "Title": "BDFL",
-            "level": "20"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+  "id": 4,
+  "created_at": "2020-03-19T22:48:54.436337Z",
+  "updated_at": "2020-03-19T22:48:54.547479Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "Name",
+          "Title",
+          "level"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [],
+            "data": {
+              "Name": "Guido",
+              "Title": "BDFL",
+              "level": "20"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "extra-value",
-              "message": "Row 4 has an extra value in column 4",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
             }
-          ],
-          "data": {
-            "Name": "Catherine",
-            "Title": "",
-            "level": "9"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 5 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 4,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "extra-value",
+                "message": "Row 4 has an extra value in column 4",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "Catherine",
+              "Title": "",
+              "level": "9"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 5 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
+            }
+          },
+          {
+            "row_number": 6,
+            "errors": [],
+            "data": {
+              "Name": "Tony",
+              "Title": "Engineer",
+              "level": "10"
+            }
           }
-        },
-        {
-          "row_number": 6,
-          "errors": [],
-          "data": {
-            "Name": "Tony",
-            "Title": "Engineer",
-            "level": "10"
-          }
-        }
-      ],
-      "valid_row_count": 2,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 2,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 
@@ -776,87 +816,97 @@ curl -s -X PATCH \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "extra",
-        "level",
-        "Title",
-        "Name"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 2 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+  "id": 1,
+  "created_at": "2020-03-19T22:47:40.509878Z",
+  "updated_at": "2020-03-19T22:49:12.748836Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "extra",
+          "level",
+          "Title",
+          "Name"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 2 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "20",
+              "Title": "BDFL",
+              "Name": "Guido"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "20",
-            "Title": "BDFL",
-            "Name": "Guido"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": null,
+              "Title": null,
+              "Name": null
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": null,
-            "Title": null,
-            "Name": null
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [],
-          "data": {
-            "extra": "information",
-            "level": 9,
-            "Title": "DBA",
-            "Name": "Catherine"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "missing-value",
-              "message": "Row 5 has a missing value in column 1 (extra)",
-              "fields": [
-                "extra"
-              ]
+          },
+          {
+            "row_number": 4,
+            "errors": [],
+            "data": {
+              "extra": "information",
+              "level": 9,
+              "Title": "DBA",
+              "Name": "Catherine"
             }
-          ],
-          "data": {
-            "extra": null,
-            "level": "10",
-            "Title": "Engineer",
-            "Name": "Tony"
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "missing-value",
+                "message": "Row 5 has a missing value in column 1 (extra)",
+                "fields": [
+                  "extra"
+                ]
+              }
+            ],
+            "data": {
+              "extra": null,
+              "level": "10",
+              "Title": "Engineer",
+              "Name": "Tony"
+            }
           }
-        }
-      ],
-      "valid_row_count": 1,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 1,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 
@@ -874,87 +924,97 @@ curl -s -X PATCH \
 
 ```json
 {
-  "tables": [
-    {
-      "headers": [
-        "Name",
-        "Title",
-        "level"
-      ],
-      "whole_table_errors": [],
-      "rows": [
-        {
-          "row_number": 2,
-          "errors": [],
-          "data": {
-            "Name": "Guido",
-            "Title": "BDFL",
-            "level": "20"
-          }
-        },
-        {
-          "row_number": 3,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 3 is completely blank",
-              "fields": []
+  "id": 2,
+  "created_at": "2020-03-19T22:48:15.770146Z",
+  "updated_at": "2020-03-19T22:49:25.857647Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "tables": [
+      {
+        "headers": [
+          "Name",
+          "Title",
+          "level"
+        ],
+        "whole_table_errors": [],
+        "rows": [
+          {
+            "row_number": 2,
+            "errors": [],
+            "data": {
+              "Name": "Guido",
+              "Title": "BDFL",
+              "level": "20"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
-          }
-        },
-        {
-          "row_number": 4,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "extra-value",
-              "message": "Row 4 has an extra value in column 4",
-              "fields": []
+          },
+          {
+            "row_number": 3,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 3 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
             }
-          ],
-          "data": {
-            "Name": "Catherine",
-            "Title": "",
-            "level": "9"
-          }
-        },
-        {
-          "row_number": 5,
-          "errors": [
-            {
-              "severity": "Error",
-              "code": "blank-row",
-              "message": "Row 5 is completely blank",
-              "fields": []
+          },
+          {
+            "row_number": 4,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "extra-value",
+                "message": "Row 4 has an extra value in column 4",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "Catherine",
+              "Title": "",
+              "level": "9"
             }
-          ],
-          "data": {
-            "Name": "",
-            "Title": "",
-            "level": ""
+          },
+          {
+            "row_number": 5,
+            "errors": [
+              {
+                "severity": "Error",
+                "code": "blank-row",
+                "message": "Row 5 is completely blank",
+                "fields": []
+              }
+            ],
+            "data": {
+              "Name": "",
+              "Title": "",
+              "level": ""
+            }
+          },
+          {
+            "row_number": 6,
+            "errors": [],
+            "data": {
+              "Name": "Tony",
+              "Title": "Engineer",
+              "level": "10"
+            }
           }
-        },
-        {
-          "row_number": 6,
-          "errors": [],
-          "data": {
-            "Name": "Tony",
-            "Title": "Engineer",
-            "level": "10"
-          }
-        }
-      ],
-      "valid_row_count": 2,
-      "invalid_row_count": 3
-    }
-  ],
-  "valid": false
+        ],
+        "valid_row_count": 2,
+        "invalid_row_count": 3
+      }
+    ],
+    "valid": false
+  }
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1215,30 +1215,9 @@ curl -X POST \
 
 ## Python
 
-We provide a sample python example, which uses the [`requests` library](https://requests.readthedocs.io/en/master/ "requests library").
+We provide [a sample python example](example.py "a sample python example"), which uses the [`requests` library](https://requests.readthedocs.io/en/master/ "requests library"). This example demonstrates the standard life-cycle of an upload instance.
 
-<details><summary>API</summary>
-
-TODO run examples
-
-```python
-import requests
-
-
-url = "http://localhost:8000/data_ingest/api/"
-
-with open("test_cases.json") as infile:  # or "test_cases.csv"
-    content = infile.read()
-resp = requests.post(url,
-                     data=content,
-                     headers={
-                        "Content-Type": "application/json",  # or "text/csv"
-                        "Authorization": "Token <token>"
-                     })
-resp.json()
-```
-
-</details>
+A validation example is also provided below.
 
 <details><summary>Validate</summary>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -157,19 +157,28 @@ resp.json()
 
 </details>
 
-## Validation responses
+## List uploads
+## Get upload
+## Create upload
+## Replace upload
+## Replace upload in-place
+## Delete upload
+## Stage upload
+## Insert upload
+
+# Validation
+
+## Validation response structure
 
 After data is posted to the `validate` endpoint, one will expect a JSON response.
 
-#### Code: 200 - OK
-
-##### Description
+### Description
 
 The response will be a JSON object with the following items:
   - **tables** - a list of **table** JSON objects
   - **valid** - boolean to indicates whether the data is valid or not
 
-##### Definitions
+### Definitions
   - **table** - a JSON object with the following items:
     - **headers** - a list of field names for the data (for tabular data and flat JSON data)
     - **whole_table_errors** - a list of **error** JSON objects that are related to the entire table
@@ -190,7 +199,7 @@ The response will be a JSON object with the following items:
     - **message** - error message that describe what the error is
     - **fields** - a list of all the field names that are associated with this error
 
-##### Example Value
+<details><summary>Example validation response</summary>
 
 ```json
 {
@@ -267,18 +276,20 @@ The response will be a JSON object with the following items:
 }
 ```
 
-# Validator error codes
+</details>
+
+## Validator error codes
 
 Each validator provides a different set of error codes. Some of these error codes are provided by the validator based on the available checks it performs. Some validators will require the application owner to define their own set of error codes. In this case, the application owner will have to provide their own error code specification.
 
-## GoodTables validator
+### GoodTables validator
 
 The GoodTables validator comes with its own set of error codes.  See the [validation documentation](https://github.com/frictionlessdata/goodtables-py#validation). There is also a [data quality specification](https://github.com/frictionlessdata/data-quality-spec/blob/master/spec.json) that defines all the available error codes from GoodTables.
 
-## Rowwise validator
+### Rowwise validator
 
 This validator includes both a JSON Logic Validator and SQL Validator.  This type of validator requires the application owner to define an error code for each rule definition.  Check with the application owner to obtain a list of error codes.  For more details on how to create your own rules, see [documentation on customizing a rowwise validator](customize.md#with-a-rowwise-validator).
 
-## JSON Schema validator
+### JSON Schema validator
 
 The JSON Schema validator comes with its own set of error codes.  The error code is the "validator" being used by the recommended [Python JSONSchema Validation](https://github.com/Julian/jsonschema). [Validation keywords](https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.6) will be used as error codes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,38 +64,44 @@ One way to do this is to log in as a super user and use the Django `/admin` inte
 1. Add an user (if not already done) at `/admin/auth/user/add/`.
 2. Create a new token at `/admin/authtoken/token/add/`.
 
+This token may be retrieved by the user ([see the `Obtaining a Token` example below](#obtaining-a-token "obtaining a token below")).
+
 # Examples
 
-
-### Obtain Token
+## Obtaining a Token
 
 `POST` to `/data_ingest/api/api-token-auth` to get the token for authentication.
 
 ```bash
 curl -X POST \
--F username=<replace with what the admin gives you> \
--F password=<replace with what the admin gives you> \
-http://localhost:8000/data_ingest/api/api-token-auth/
+  -F username=<your username> \
+  -F password=<your password> \
+  http://localhost:8000/data_ingest/api/api-token-auth/
 ```
 
 You will get a JSON response back with the token:
+
 ```json
-{"token": "<Token to use for authentication on validate API>"}
+{"token": "<Token to use for authentication>"}
 ```
 
-Use this token in the header as shown below.
+Use this token in the header for the rest of the examples below.
 
-### Validate JSON data
+## Validating JSON data
+
+<details><summary>Curl</summary>
 
 ```bash
 curl -X POST \
--H "Content-Type: application/json" \
--H "Authorization: Token <Replace with your Token here>" \
--d @test_cases.json \
-http://localhost:8000/data_ingest/api/validate/
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token <Replace with your Token here>" \
+  -d @test_cases.json \
+  http://localhost:8000/data_ingest/api/validate/
 ```
 
-or, in Python,
+</details>
+
+<details><summary>Python</summary>
 
 ```python
 import requests
@@ -109,22 +115,28 @@ with open('test_cases.json') as infile:
 resp = requests.post(url,
                      json=content,
                      headers={
-                        "Authorization": "Token <Replace with Token here in the form of environment variables, not raw text in the code>"
+                        "Authorization": "Token <token>"
                      })
 resp.json()
 ```
 
-### Validate CSV data
+</details>
+
+## Validating CSV data
+
+<details><summary>Curl</summary>
 
 ```bash
 curl -X POST \
--H "Content-Type: text/csv" \
--H "Authorization: Token <Replace with your Token here>" \
---data-binary @test_cases.csv \
-http://localhost:8000/data_ingest/api/validate/
+  -H "Content-Type: text/csv" \
+  -H "Authorization: Token <token>" \
+  --data-binary @test_cases.csv \
+  http://localhost:8000/data_ingest/api/validate/
 ```
 
-or, in Python,
+</details>
+
+<details><summary>Python</summary>
 
 ```python
 import requests
@@ -138,12 +150,14 @@ resp = requests.post(url,
                      data=content,
                      headers={
                         "Content-Type": "text/csv",
-                        "Authorization": "Token <Replace with Token here in the form of environment variables, not raw text in the code>"
+                        "Authorization": "Token <token>"
                      })
 resp.json()
 ```
 
-### Responses
+</details>
+
+## Validation responses
 
 After data is posted to the `validate` endpoint, one will expect a JSON response.
 
@@ -253,35 +267,18 @@ The response will be a JSON object with the following items:
 }
 ```
 
-##### Error Codes
+# Validator error codes
 
-Each validator will provide a different set of error codes.  Some of the codes will be provided by the validator based on the available checks it performs.  Some validators will require app's owner to define their own set of error codes.  In this case, the app's owner will provide the error code specification.
+Each validator provides a different set of error codes. Some of these error codes are provided by the validator based on the available checks it performs. Some validators will require the application owner to define their own set of error codes. In this case, the application owner will have to provide their own error code specification.
 
-###### GoodTables Validator
+## GoodTables validator
 
-GoodTables validator comes with its own set of error codes.  See the [validation](https://github.com/frictionlessdata/goodtables-py#validation) it performs where each check is an error code. Here's the [data quality specification](https://github.com/frictionlessdata/data-quality-spec/blob/master/spec.json) that defines all the available error codes from GoodTables.
+The GoodTables validator comes with its own set of error codes.  See the [validation documentation](https://github.com/frictionlessdata/goodtables-py#validation). There is also a [data quality specification](https://github.com/frictionlessdata/data-quality-spec/blob/master/spec.json) that defines all the available error codes from GoodTables.
 
-###### Rowwise Validator
+## Rowwise validator
 
-This includes both JSON Logic Validator and SQL Validator.  This type of validators requires the app's owner to define an error code for each rule definition.  Check with app's owner to obtain a list of error codes.  For more details on how to create your own rules, see [documentation on customizing a rowwise validator](customize.md#with-a-rowwise-validator).
+This validator includes both a JSON Logic Validator and SQL Validator.  This type of validator requires the application owner to define an error code for each rule definition.  Check with the application owner to obtain a list of error codes.  For more details on how to create your own rules, see [documentation on customizing a rowwise validator](customize.md#with-a-rowwise-validator).
 
-###### JSON Schema Validator
+## JSON Schema validator
 
-JSON Schema validator comes with its own set of error codes.  The error code is the "validator" being used by the recommended [Python JSONSchema Validation](https://github.com/Julian/jsonschema).  The [validation keywords](https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.6) will be used as the error code.
-
-#### Code: 400 - Bad Request
-
-##### Description
-
-The response will be a JSON object to indicate the error.
-
-
-##### Example Value
-
-i.e. This is to indicate incorrect JSON format when media type is JSON.
-
-```json
-{
-    "detail": "JSON parse error - Expecting value: line 1 column 1 (char 0)"
-}
-```
+The JSON Schema validator comes with its own set of error codes.  The error code is the "validator" being used by the recommended [Python JSONSchema Validation](https://github.com/Julian/jsonschema). [Validation keywords](https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.6) will be used as error codes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,7 +158,101 @@ curl -s -X GET \
 ```
 
 ```json
-TODO
+[
+  {
+    "id": 1,
+    "created_at": "2020-03-19T21:30:00.836189Z",
+    "updated_at": "2020-03-19T21:30:00.944063Z",
+    "status": "LOADING",
+    "status_changed_by": null,
+    "status_changed_at": null,
+    "submitter": 1,
+    "file_metadata": {},
+    "validation_results": {
+      "valid": false,
+      "tables": [
+        {
+          "rows": [
+            {
+              "data": {
+                "Name": "Guido",
+                "Title": "BDFL",
+                "extra": null,
+                "level": "20"
+              },
+              "errors": [
+                {
+                  "code": "missing-value",
+                  "fields": [
+                    "extra"
+                  ],
+                  "message": "Row 2 has a missing value in column 1 (extra)",
+                  "severity": "Error"
+                }
+              ],
+              "row_number": 2
+            },
+            {
+              "data": {
+                "Name": null,
+                "Title": null,
+                "extra": null,
+                "level": null
+              },
+              "errors": [
+                {
+                  "code": "blank-row",
+                  "fields": [],
+                  "message": "Row 3 is completely blank",
+                  "severity": "Error"
+                }
+              ],
+              "row_number": 3
+            },
+            {
+              "data": {
+                "Name": "Catherine",
+                "Title": "DBA",
+                "extra": "information",
+                "level": 9
+              },
+              "errors": [],
+              "row_number": 4
+            },
+            {
+              "data": {
+                "Name": "Tony",
+                "Title": "Engineer",
+                "extra": null,
+                "level": "10"
+              },
+              "errors": [
+                {
+                  "code": "missing-value",
+                  "fields": [
+                    "extra"
+                  ],
+                  "message": "Row 5 has a missing value in column 1 (extra)",
+                  "severity": "Error"
+                }
+              ],
+              "row_number": 5
+            }
+          ],
+          "headers": [
+            "extra",
+            "level",
+            "Title",
+            "Name"
+          ],
+          "valid_row_count": 1,
+          "invalid_row_count": 3,
+          "whole_table_errors": []
+        }
+      ]
+    }
+  }
+]
 ```
 
 </details>
@@ -175,7 +269,99 @@ curl -s -X GET \
 ```
 
 ```json
-TODO
+{
+  "id": 1,
+  "created_at": "2020-03-19T21:30:00.836189Z",
+  "updated_at": "2020-03-19T21:30:00.944063Z",
+  "status": "LOADING",
+  "status_changed_by": null,
+  "status_changed_at": null,
+  "submitter": 1,
+  "file_metadata": {},
+  "validation_results": {
+    "valid": false,
+    "tables": [
+      {
+        "rows": [
+          {
+            "data": {
+              "Name": "Guido",
+              "Title": "BDFL",
+              "extra": null,
+              "level": "20"
+            },
+            "errors": [
+              {
+                "code": "missing-value",
+                "fields": [
+                  "extra"
+                ],
+                "message": "Row 2 has a missing value in column 1 (extra)",
+                "severity": "Error"
+              }
+            ],
+            "row_number": 2
+          },
+          {
+            "data": {
+              "Name": null,
+              "Title": null,
+              "extra": null,
+              "level": null
+            },
+            "errors": [
+              {
+                "code": "blank-row",
+                "fields": [],
+                "message": "Row 3 is completely blank",
+                "severity": "Error"
+              }
+            ],
+            "row_number": 3
+          },
+          {
+            "data": {
+              "Name": "Catherine",
+              "Title": "DBA",
+              "extra": "information",
+              "level": 9
+            },
+            "errors": [],
+            "row_number": 4
+          },
+          {
+            "data": {
+              "Name": "Tony",
+              "Title": "Engineer",
+              "extra": null,
+              "level": "10"
+            },
+            "errors": [
+              {
+                "code": "missing-value",
+                "fields": [
+                  "extra"
+                ],
+                "message": "Row 5 has a missing value in column 1 (extra)",
+                "severity": "Error"
+              }
+            ],
+            "row_number": 5
+          }
+        ],
+        "headers": [
+          "extra",
+          "level",
+          "Title",
+          "Name"
+        ],
+        "valid_row_count": 1,
+        "invalid_row_count": 3,
+        "whole_table_errors": []
+      }
+    ]
+  }
+}
 ```
 
 </details>
@@ -193,7 +379,89 @@ curl -s -X POST \
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "extra",
+        "level",
+        "Title",
+        "Name"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 2 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "20",
+            "Title": "BDFL",
+            "Name": "Guido"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": null,
+            "Title": null,
+            "Name": null
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [],
+          "data": {
+            "extra": "information",
+            "level": 9,
+            "Title": "DBA",
+            "Name": "Catherine"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 5 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "10",
+            "Title": "Engineer",
+            "Name": "Tony"
+          }
+        }
+      ],
+      "valid_row_count": 1,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -209,7 +477,89 @@ curl -s -X POST \
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "Name",
+        "Title",
+        "level"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [],
+          "data": {
+            "Name": "Guido",
+            "Title": "BDFL",
+            "level": "20"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "extra-value",
+              "message": "Row 4 has an extra value in column 4",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "Catherine",
+            "Title": "",
+            "level": "9"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 5 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 6,
+          "errors": [],
+          "data": {
+            "Name": "Tony",
+            "Title": "Engineer",
+            "level": "10"
+          }
+        }
+      ],
+      "valid_row_count": 2,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -227,7 +577,89 @@ curl -s -X PUT \
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "extra",
+        "level",
+        "Title",
+        "Name"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 2 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "20",
+            "Title": "BDFL",
+            "Name": "Guido"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": null,
+            "Title": null,
+            "Name": null
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [],
+          "data": {
+            "extra": "information",
+            "level": 9,
+            "Title": "DBA",
+            "Name": "Catherine"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 5 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "10",
+            "Title": "Engineer",
+            "Name": "Tony"
+          }
+        }
+      ],
+      "valid_row_count": 1,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -239,11 +671,93 @@ curl -s -X PUT \
   --data-binary @test_cases.csv \
   -H "Content-Type: text/csv" \
   -H "Authorization: Token faketoken" \
-  http://localhost:8000/data_ingest/api/1/
+  http://localhost:8000/data_ingest/api/2/
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "Name",
+        "Title",
+        "level"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [],
+          "data": {
+            "Name": "Guido",
+            "Title": "BDFL",
+            "level": "20"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "extra-value",
+              "message": "Row 4 has an extra value in column 4",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "Catherine",
+            "Title": "",
+            "level": "9"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 5 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 6,
+          "errors": [],
+          "data": {
+            "Name": "Tony",
+            "Title": "Engineer",
+            "level": "10"
+          }
+        }
+      ],
+      "valid_row_count": 2,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -261,7 +775,89 @@ curl -s -X PATCH \
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "extra",
+        "level",
+        "Title",
+        "Name"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 2 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "20",
+            "Title": "BDFL",
+            "Name": "Guido"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": null,
+            "Title": null,
+            "Name": null
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [],
+          "data": {
+            "extra": "information",
+            "level": 9,
+            "Title": "DBA",
+            "Name": "Catherine"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "missing-value",
+              "message": "Row 5 has a missing value in column 1 (extra)",
+              "fields": [
+                "extra"
+              ]
+            }
+          ],
+          "data": {
+            "extra": null,
+            "level": "10",
+            "Title": "Engineer",
+            "Name": "Tony"
+          }
+        }
+      ],
+      "valid_row_count": 1,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -273,11 +869,93 @@ curl -s -X PATCH \
   --data-binary @test_cases.csv \
   -H "Content-Type: text/csv" \
   -H "Authorization: Token faketoken" \
-  http://localhost:8000/data_ingest/api/1/
+  http://localhost:8000/data_ingest/api/2/
 ```
 
 ```json
-TODO
+{
+  "tables": [
+    {
+      "headers": [
+        "Name",
+        "Title",
+        "level"
+      ],
+      "whole_table_errors": [],
+      "rows": [
+        {
+          "row_number": 2,
+          "errors": [],
+          "data": {
+            "Name": "Guido",
+            "Title": "BDFL",
+            "level": "20"
+          }
+        },
+        {
+          "row_number": 3,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 3 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 4,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "extra-value",
+              "message": "Row 4 has an extra value in column 4",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "Catherine",
+            "Title": "",
+            "level": "9"
+          }
+        },
+        {
+          "row_number": 5,
+          "errors": [
+            {
+              "severity": "Error",
+              "code": "blank-row",
+              "message": "Row 5 is completely blank",
+              "fields": []
+            }
+          ],
+          "data": {
+            "Name": "",
+            "Title": "",
+            "level": ""
+          }
+        },
+        {
+          "row_number": 6,
+          "errors": [],
+          "data": {
+            "Name": "Tony",
+            "Title": "Engineer",
+            "level": "10"
+          }
+        }
+      ],
+      "valid_row_count": 2,
+      "invalid_row_count": 3
+    }
+  ],
+  "valid": false
+}
 ```
 
 </details>
@@ -290,7 +968,7 @@ TODO
 curl -s -X DELETE \
   -H "Content-Type: application/json" \
   -H "Authorization: Token faketoken" \
-  http://localhost:8000/data_ingest/api/4
+  http://localhost:8000/data_ingest/api/3
 ```
 
 ```json
@@ -308,7 +986,7 @@ Note: on success, a 204 (no content) response code is returned.
 curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Token faketoken" \
-  http://localhost:8000/data_ingest/api/5/stage/
+  http://localhost:8000/data_ingest/api/4/stage/
 ```
 
 ```json
@@ -326,7 +1004,7 @@ Note: on success, a 204 (no content) response code is returned.
 curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Token faketoken" \
-  http://localhost:8000/data_ingest/api/6/insert/
+  http://localhost:8000/data_ingest/api/5/insert/
 ```
 
 ```json

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -1,32 +1,18 @@
 # Customizing validation
 
-By default, data_ingest applies only the
-[default GoodTables validator](https://github.com/frictionlessdata/goodtables-py)
-which checks for basic problems like empty rows,
-rows with more columns than the header, etc.
+The default `data_ingest` settings configure only one validator: the [default GoodTables validator](https://github.com/frictionlessdata/goodtables-py) which checks for basic problems like empty rows, rows with more columns than the header, etc.
 
 ## Specifying `VALIDATORS`
 
-Any number of validators can be applied by adding them to 
-`DATA_INGEST['VALIDATORS']`.  The key should be the filename
-(or URL of a file to be downloaded); the value should be the 
-validator class used with that file.  `data_ingest` supplies
-built-in validators for 
-[Table Schema](https://frictionlessdata.io/specs/table-schema/),
-[JsonLogic](http://jsonlogic.com/), 
-and [sqlite](https://www.sqlite.org/index.html) SQL.
+Any number of validators can be added to `DATA_INGEST['VALIDATORS']`.  The key should be the filename (or URL of a file to be downloaded); the value should be the validator class used with that file.  `data_ingest` supplies built-in validators for [Table Schema](https://frictionlessdata.io/specs/table-schema/), [JsonLogic](http://jsonlogic.com/), and [sqlite](https://www.sqlite.org/index.html) SQL.
 
-If the order of application is 
-important, `DATA_INGEST['VALIDATORS']` can be an 
-[OrderedDict](https://docs.python.org/3/library/collections.html#collections.OrderedDict).
+If the order of application is important, `DATA_INGEST['VALIDATORS']` can be an [OrderedDict](https://docs.python.org/3/library/collections.html#collections.OrderedDict).
 
-## With a whole-table validator 
+## With a whole-table validator
 
 ### With a custom Table Schema
 
-[Table Schema](https://frictionlessdata.io/specs/table-schema/)
-supports a variety of validations.  Any valid TableSchema
-can be applied to uploads by including it in `DATA_INGEST['VALIDATORS']` in `settings.py`.
+[Table Schema](https://frictionlessdata.io/specs/table-schema/) supports a variety of validations.  Any valid TableSchema can be applied to uploads by including it in `DATA_INGEST['VALIDATORS']` in `settings.py`.
 
 ```python
     'VALIDATORS': {
@@ -34,16 +20,13 @@ can be applied to uploads by including it in `DATA_INGEST['VALIDATORS']` in `set
     }
 ```
 
-This can be a file path relative to the Django project's root,
-or the URL of a Table Schema on the web.
+This can be a file path relative to the Django project's root, or the URL of a Table Schema on the web.
 
-## With a rowwise validator 
+## With a row-wise validator
 
-Rowwise validators are applied individually to each row, and 
-require a definition file in JSON or YAML specifying a list of rules.  
-Each rule is an object with `code` and a `message`.
+Row-Wise validators are applied individually to each row, and require a definition file in JSON or YAML specifying a list of rules. Each rule is an object with `code` and a `message`.
 
-These rules may look like 
+These rules may look like the following:
 
 ```json
     {
@@ -55,7 +38,7 @@ These rules may look like
     }
 ```
 
-### Required fields 
+### Required fields
 
 - `code`: An expression in the appropriate language (such as SQL or JsonLogic)
 - `message`: Text to display to submitter when a row violates this rule.
@@ -71,20 +54,19 @@ inside the curly brackets `{}` will be evaluated and replaced by its value.
 - `{A op B:C}`: `A op B` is the same as above, `C` is the number of decimal places to display
   after the decimal.
 
-### Optional fields 
+### Optional fields
 
 - `error_code`: A user-defined code for this rule
 - `columns`: Names of columns to highlight when a row violates this rule.  Optional.
-- `severity`: `Warning` or `Error`, defaults to `Error`.  `Warning` will not prevent 
+- `severity`: `Warning` or `Error`, defaults to `Error`.  `Warning` will not prevent
   rows from being inserted.
- 
+
 Any extra fields will be ignored.
 
-
-### With [JSON Logic](http://jsonlogic.com/) 
+### With [JSON Logic](http://jsonlogic.com/)
 
 Create a YAML or JSON list of JSON Logic rules, as described above,
-and add the file to `DATA_INGEST['VALIDATORS']`. 
+and add the file to `DATA_INGEST['VALIDATORS']`.
 
 ```python
     'VALIDATORS': {
@@ -95,7 +77,7 @@ and add the file to `DATA_INGEST['VALIDATORS']`.
 ### With SQL
 
 Create a YAML or JSON list of SQL, as described above,
-and add the file to `DATA_INGEST['VALIDATORS']`. 
+and add the file to `DATA_INGEST['VALIDATORS']`.
 
 ```python
     'VALIDATORS': {
@@ -107,9 +89,9 @@ Each rule's code should return `true` for valid rows and `false` for invalid.
 
 At this point, SQL Validator uses in-memory SQLite database to perform its validation.
 
-### Inverting rule logic 
+### Inverting rule logic
 
-By default, the code of each rule should evaluate to `true` for a row 
+By default, the code of each rule should evaluate to `true` for a row
 to be valid.  You can reverse this by defining a new validator and making the attribute `INVERT_LOGIC = True`.  There are currently two validators that do the invert rule logic: `JsonlogicValidatorFailureConditions`, and `SqlValidatorFailureConditions`.  See code in `ingestors.py` for details.
 
 ## With a JSON Schema validator
@@ -129,7 +111,7 @@ can be applied by including it in `DATA_INGEST['VALIDATORS']` in `settings.py`.
 This can be a file path relative to the Django project's root,
 or the URL of a JSON Schema on the web.
 
-Please note that when using JSON Schema Validator, you will not be able to use other tabular and rowwise validator as they are incompatible.
+Please note that when using JSON Schema Validator, you will not be able to use other tabular and row-wise validator as they are incompatible.
 
 # Creating a new built-in validator
 
@@ -139,18 +121,18 @@ All validators are inherited from a base `Validator` class, which requires to de
 
 You can refer to the code in `ingestor.py` for more details.
 
-## Subclassing rowwise validator
+## Subclassing row-wise validator
 
-If you need to create a validator that focuses on validating within each tabular row, you can subclass the `RowwiseValidator`.  This validator requires an implementation of `evaluate` method.
+If you need to create a validator that focuses on validating within each tabular row, you can subclass the `Row-WiseValidator`.  This validator requires an implementation of `evaluate` method.
 
 `evaluate` will takes in a rule and a row of data.  It will evaluate the row (which is a dictionary of key (field name)/value (field data) pair) based on the rule.  It will return a boolean.
 
 
 # Customizing data ingestion behavior
 
-## tabulator.Stream arguments 
+## tabulator.Stream arguments
 
-Data is extracted from uploaded files using 
+Data is extracted from uploaded files using
 [Frictionless Data's tabulator](https://github.com/frictionlessdata/tabulator-py/),
 and any arguments in the dictionary `settings.py:DATA_INGEST['STREAM_ARGS']`
 will be passed to `Stream`.  For example,
@@ -161,16 +143,16 @@ will be passed to `Stream`.  For example,
     }
 ```
 
-would extract data from the `Data` sheet of a spreadsheet workbook, and would 
+would extract data from the `Data` sheet of a spreadsheet workbook, and would
 use lines 3 and 4 as column headers.
 
-## Customizing ingestors 
+## Customizing ingestors
 
-If the files are in a format more irregular than 
-[tabulator](https://github.com/frictionlessdata/tabulator-py) 
+If the files are in a format more irregular than
+[tabulator](https://github.com/frictionlessdata/tabulator-py)
 can handle format (like spreadsheets
-where the relevant cells are not in a contiguous block), you 
-can sublass `ingestors.py:Ingestor`.  
+where the relevant cells are not in a contiguous block), you
+can sublass `ingestors.py:Ingestor`.
 
 ## Adding metadata
 
@@ -193,9 +175,7 @@ field of `Upload` instances.
 
 ### Enforcing metadata uniqueness
 
-You may want to prevent multiple copies of the same file being uploaded.
-A combination of metadata fields can be specified that will be used to
-enforce uniqueness.  To do so, after setting up the metadata fields (as above),
+You may want to prevent multiple copies of the same file being uploaded. A combination of metadata fields can be specified that will be used to enforce uniqueness.  To do so, after setting up the metadata fields (as above),
 
 1. Create a subclass of `data_ingest.models.Upload` with the fields you want to enforce as being unique (together).  [Example](../examples/p02_budgets/budget_data_ingest.models.py)
 
@@ -207,11 +187,9 @@ enforce uniqueness.  To do so, after setting up the metadata fields (as above),
     }
 ```
 
-### Metadata prefix 
+### Metadata prefix
 
-You may want to distinguish metadata fields from row data when 
-inserting data to its final destination.  If so, use the `METADATA_PREFIX`
-setting:
+You may want to distinguish metadata fields from row data when inserting data to its final destination. If so, use the `METADATA_PREFIX` setting:
 
 ```python
     DATA_INGEST = {
@@ -219,30 +197,23 @@ setting:
     }
 ```
 
-`METADATA_PREFIX` will also be attached to `row_number` in the inserted
-data.
+`METADATA_PREFIX` will also be attached to `row_number` in the inserted data.
 
-This can help avoid field name collisions if uploaded files have fields 
-with the same name as metadata fields.
+This can help avoid field name collisions if uploaded files have fields with the same name as metadata fields.
 
 # Changing injection destination
 
-We "inject" data when we copy it from an `Upload` instance into
-the data destination.  By default, each `Upload` is dumped as a
-.json file in the `data_ingest/` directory under the Django
-project root.  
+We "inject" data when we copy it from an `Upload` instance into the data destination.  By default, each `Upload` is dumped as a .json file in the `data_ingest/` directory under the Django project root.
 
-Change `DATA_INGEST['DESTINATION']` in settings.py 
-to save it elsewhere.
+Change `DATA_INGEST['DESTINATION']` in settings.py to save it elsewhere.
 
-## To a RESTful web service 
+## To a RESTful web service
 
-Set `DATA_INGEST['DESTINATION_FORMAT']` to a webservice endpoint's 
-full URL, and the upload contents will be POSTed there as JSON.
- 
+Set `DATA_INGEST['DESTINATION_FORMAT']` to a webservice endpoint's full URL, and the upload contents will be POSTed there as JSON.
+
 ## To a different flat-file format
 
-Change `DATA_INGEST['DESTINATION_FORMAT']` to save the file in a 
+Change `DATA_INGEST['DESTINATION_FORMAT']` to save the file in a
 different format.  So far `yaml`, `json`, and `csv` are supported.
 
 To add a format not yet supported,
@@ -250,7 +221,7 @@ To add a format not yet supported,
 - Subclass `ingestors.py:Ingestor` and give it an `insert_yourformat(self)`
 method modeled on `Ingestor.insert_json`
 
-- Include `yourextension: insert_yourmodel` in your subclass' `inserters` 
+- Include `yourextension: insert_yourmodel` in your subclass' `inserters`
 attribute.
 
 - Edit your settings to use the new ingestor subclass.
@@ -259,17 +230,14 @@ attribute.
      INGEST_SETTINGS = {
         'INGESTOR': 'yourpackage.ingestors.YourIngestor',
         'DESTINATION_FORMAT': 'yourextension',
-    }   
+    }
 ```
 
-There is an example of adding a custom injection destination type 
-in [examples/p03_budget](examples/p03_budgets).
+There is an example of adding a custom injection destination type in [examples/p03_budget](examples/p03_budgets).
 
 ## To a Django model
 
-To save uploaded rows to instances of a Django data model
-(rows in an underlying relational database), set
-`'DJANGO_INGEST'['DESTINATION']` in `settings.py`:
+To save uploaded rows to instances of a Django data model (rows in an underlying relational database), set `'DJANGO_INGEST'['DESTINATION']` in `settings.py`:
 
 ```python
     DATA_INGEST = {
@@ -277,21 +245,11 @@ To save uploaded rows to instances of a Django data model
     }
 ```
 
-Of course, the target model must exist!  See this
-[example module](../examples/p02_budget/models.py).
-Include model fields for the data columns, the metadata fields,
-a `ForeignKey` to the `Upload` model, and a `row_number` 
-field.
+Of course, the target model must exist!  See this [example module](../examples/p02_budget/models.py). Include model fields for the data columns, the metadata fields, a `ForeignKey` to the `Upload` model, and a `row_number` field.
 
 # Overriding headers
 
-When using rowwise validators (SQL or JsonLogic), It's possible to validate data submitted with inconsistently named headers 
-as long as they appear in a consistent order.  Specify a list of headers in 
-`settings.py:DATA_INGEST['STREAM_ARGS']['headers']`, 
-then specify the row number of the to-be-replaced headers in  
-`settings.py:DATA_INGEST['OLD_HEADER_ROW']`.  The user-supplied 
-headers will still be used in the output, but the headers from settings.py
-will be used for validation rules.
+When using row-wise validators (SQL or JsonLogic), It's possible to validate data submitted with inconsistently named headers as long as they appear in a consistent order.  Specify a list of headers in `settings.py:DATA_INGEST['STREAM_ARGS']['headers']`, then specify the row number of the to-be-replaced headers in `settings.py:DATA_INGEST['OLD_HEADER_ROW']`.  The user-supplied
+headers will still be used in the output, but the headers from settings.py will be used for validation rules.
 
-There is an example of overriding headers 
-in [examples/p03_budget](examples/p03_budgets).
+There is an example of overriding headers in [examples/p03_budget](examples/p03_budgets).

--- a/docs/default.md
+++ b/docs/default.md
@@ -7,13 +7,16 @@ An example is available at [examples/defaults](../examples/defaults.md)
 ## Creating the minimal project
 
 Create a folder for your Django project name (replace `myproject` with the project name) and go into the folder:
+
 ```bash
 mkdir myproject
 cd myproject
 ```
 
 Install ReVAL:
-- Replace `<version>` with the latest tag i.e. `v0.2` or
+
+- Replace `<version>` with the latest tag i.e. `v0.7.0` or
+
 - Replace with `master` if you would like to work with the latest development version
 ```bash
     pipenv install -e git+https://github.com/18F/ReVAL.git@<version>#egg=data-ingest
@@ -38,6 +41,7 @@ INSTALLED_APPS = [
     'data_ingest',
 ]
 ```
+
 Also in `myproject/settings.py`, change the `DATABASE` settings to a PostgreSQL database.  Replace `myprojectdb` with the name of your database.
 
 ```python
@@ -80,8 +84,7 @@ Run the server.
 python manage.py runserver
 ```
 
-Visit http://localhost:8000/data_ingest/, login with the account you created, and try uploading some
-CSV files.
+Visit http://localhost:8000/data_ingest/, login with the account you created, and try uploading some CSV files.
 
 ## To run on Cloud.gov
 
@@ -93,4 +96,3 @@ Please follow the [cloud.gov deployment instruction](cloud.gov.md).
 - No metadata is added to the files.  ([To change](customize.md))
 - The only validation applied is [Goodtables](http://goodtables.okfnlabs.org/)' default validator.  This simply ensures that a CSV has a fundamentally valid form.  ([To change](customize.md))
 - Inserting files saves the data as JSON files in a `data_ingest/` directory under the project directory.  ([To change](customize.md))
-

--- a/docs/example.py
+++ b/docs/example.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#
+# Example script demonstrating API and upload model life-cycle.
+
+
+import sys
+import requests
+
+
+base_url = "http://localhost:8000/data_ingest/api"
+
+# first, obtain our token from the API.
+resp = requests.post(
+    f"{base_url}/api-token-auth/", data=dict(username="username", password="password"),
+)
+
+# do we have a valid token? if not, exit.
+token_result = resp.json()
+if "token" not in token_result:
+    print(f"error: could not obtain token: {token_result}")
+    sys.exit(1)
+token = token_result["token"]
+print(f"obtained token: {token}")
+
+# set up headers. you may set Content-Type to "text/csv" if you are
+# primarily using csv files. for this example, though, we assume json.
+headers = {
+    "Content-Type": "application/json",  # or "text/csv"
+    "Authorization": f"Token {token}",
+}
+
+# load our test data. note that we want plain string for the request
+# `data` keyword parameter, not a dictionary object.
+with open("test_cases.json") as infile:  # or "test_cases.csv"
+    content = infile.read()
+
+# create a new upload object.
+resp = requests.post(f"{base_url}/", data=content, headers=headers)
+id = resp.json()["id"]
+print(f"created a new upload with id: {id}")
+
+# set up a new upload url so we can modify this instance directly.
+upload_url = f"{base_url}/{id}"
+
+# modify the upload object. the previous instance will be saved, and
+# we will get back a new id.
+resp = requests.put(f"{upload_url}/", data=content, headers=headers)
+id = resp.json()["id"]
+print(f"modified upload, new id is: {id}")
+
+# modify the upload object in-place. the previous instance will not be
+# saved.
+resp = requests.patch(f"{upload_url}/", data=content, headers=headers)
+id = resp.json()["id"]
+print(f"modified upload in-place, id is: {id}")
+
+# ...validate this upload model further...
+
+# now that we're satisfied with validation, we may stage (mark for
+# final review).
+resp = requests.post(f"{upload_url}/stage/", data=content, headers=headers)
+print(f"staged upload, status code was: {resp.status_code}")
+
+# ...process this upload model further...
+
+# everything looks great, let's insert.
+resp = requests.post(f"{upload_url}/insert/", data=content, headers=headers)
+print(f"inserted upload, status code was: {resp.status_code}")
+
+# we're done with this upload, so delete it. note that this is a
+# "soft" delete: the original upload will still be in the database
+# with a status of "DELETED".
+resp = requests.delete(f"{upload_url}/", headers=headers)
+print(f"deleted upload, status code was: {resp.status_code}")

--- a/docs/example.py
+++ b/docs/example.py
@@ -12,7 +12,7 @@ base_url = "http://localhost:8000/data_ingest/api"
 # first, obtain our token from the API.
 resp = requests.post(
     f"{base_url}/api-token-auth/",
-    data=dict(username="your_username_here", password="your_password_here"),  #nosec
+    data=dict(username="your_username_here", password="your_password_here"),  # nosec
 )
 
 # do we have a valid token? if not, exit.

--- a/docs/example.py
+++ b/docs/example.py
@@ -11,7 +11,8 @@ base_url = "http://localhost:8000/data_ingest/api"
 
 # first, obtain our token from the API.
 resp = requests.post(
-    f"{base_url}/api-token-auth/", data=dict(username="username", password="password"),
+    f"{base_url}/api-token-auth/",
+    data=dict(username="your_username_here", password="your_password_here"),  #nosec
 )
 
 # do we have a valid token? if not, exit.


### PR DESCRIPTION
Addresses https://github.com/18F/ReVAL/issues/94

- Updates version to 0.7.0
- Bug fix: API should serialize instance, not just return validation data (otherwise PUT/PATCH methods become confusing)
- Bug fix: standardize on `stage` instead of `complete`
- Documentation:
  - Upload model statuses
  - Endpoints
  - Sample data
  - Examples for each API endpoint (in details/summary html blocks so it's not too overwhelming)
  - Example python script using `requests` that goes through the upload model lifecycle
  - [Documentation in md format (easier to read/review)](https://github.com/18F/ReVAL/blob/ad86df39594e501f81a865c3679d79ae82b5daa9/docs/api.md)